### PR TITLE
mermaid graph to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ B["Check for duplicates in the pipeline's
 training data"]
 C["Make an HTTP request to the URL
 and append some JSON metadata"]
-D["Determine whether the URL is about the
-criminal legal system (police, courts, jails)"]
+D["Determine whether the URL is about one of our
+`agency_types` (police, courts, jails)"]
 E["Determine which `agency` is described"]
 F["Determine if this is an `individual record`.
 We're after parent data sources."]

--- a/README.md
+++ b/README.md
@@ -6,9 +6,59 @@ This is the issue which spawned the repo: https://github.com/Police-Data-Accessi
 
 name | description of purpose
 --- | ---
+Agency identifier | Attempts to match URLs with an agency from our database
 HTML tag collector | Collects HTML header, meta, and title tags and appends them to a JSON file. The idea is to make a richer dataset for algorithm training and data labeling.
 ML URL Classifier (work in progress) | Classifies a set of URLs given by a CSV file using the KNN and Logistic Regression algorithms. This is a work in progress with one function experiment on a small labeled dataset (~400 observations, 1 feature, 2 classes). Pending progress involves testing the existing workflow in `main.ipynb` against a larger labeled dataset and including more labels in the classification problem.
 
 # Contributing
 
 If you make a useful bit of code, put it in a top-level directory with an appropriate name and dedicated README. Also, add it to the index.
+
+# Pipeline flow & operations
+
+Each of these steps may be attempted with regex, human identification, or machine learning. Once a property is in the JSON metadata, 
+
+```mermaid
+%% Here's a guide to mermaid syntax: https://mermaid.js.org/syntax/flowchart.html
+
+flowchart TD
+A["Start with a list of URLs
+in JSON format"]
+B["Check for duplicates in the pipeline's
+training data"]
+C["Make an HTTP request to the URL
+and append some JSON metadata"]
+D["Determine whether the URL is about the
+criminal legal system (police, courts, jails)"]
+E["Determine which `agency` is described"]
+F["Determine if this is an `individual record`.
+We're after parent data sources."]
+G["Add `name`, `description`, `record_type`
+based on request content"]
+H["Identify other metadata
+based on our pipeline"]
+I["Submit Data Sources with `agency`, `name`,
+`description`, and `record_type` to the
+approval queue"]
+J["Use newly approved Data Sources to
+train machine learning algorithms"]
+reject["Reject the URL"]
+manual["Human-identify and
+resubmit"]
+
+subgraph Happy path
+A --> B
+B --> C
+C --> D
+D -- yes --> E
+E -- found --> F
+F --> G
+G --> H
+H -- minimum criteria met --> I
+I --> J
+end
+
+D -- no --> reject
+E -- not found --> manual
+H -- incomplete --> manual
+```


### PR DESCRIPTION
### Fixes

[This issue](https://github.com/Police-Data-Accessibility-Project/data-source-identification/issues/11) has a giant flowchart which is only updateable in figma by me. I'd rather it be a living diagram for anyone to update and reference.

### Description

- adds a mermaid graph to the readme replacing the figma flowchart
- adds agency-identifier to the readme (I noticed it was missing when I was in there)

<img width="465" alt="Screen Shot 2023-10-11 at 11 58 10 AM" src="https://github.com/Police-Data-Accessibility-Project/data-source-identification/assets/30379833/84524b0f-7e11-4005-a490-69bd0652e797">

