### PR TITLE
Tag collector: root_page_title fixes

### DIFF
--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -50,7 +50,7 @@ class RootURLCache:
                 except Exception as e:
                     return f"Error retrieving title: {e}"
             except Exception as e:
-                return f"Error retrieving title: {e}"
+                return ""
 
             soup = BeautifulSoup(response.text, 'html.parser')
             try:

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -8,6 +8,8 @@ import ssl
 
 from common import get_user_agent
 
+DEBUG = False
+
 class RootURLCache:
     def __init__(self, cache_file='url_cache.json'):
         self.cache_file = cache_file
@@ -48,9 +50,9 @@ class RootURLCache:
                 try:
                     response = requests.get(root_url, headers=headers, timeout=120, verify=False)
                 except Exception as e:
-                    return f"Error retrieving title: {e}"
+                    return handle_exception(e)
             except Exception as e:
-                return ""
+                return handle_exception(e)
 
             soup = BeautifulSoup(response.text, 'html.parser')
             try:
@@ -68,3 +70,9 @@ class RootURLCache:
             return title
 
         return self.cache[root_url]
+
+        def handle_exception(e):
+            if DEBUG:
+                return f"Error retrieving title: {e}"
+            else:
+                return ""

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -41,7 +41,6 @@ class RootURLCache:
 
         if root_url not in self.cache:
             try:
-                print(root_url)
                 response = requests.get(root_url, headers=headers)
             except (requests.exceptions.SSLError, ssl.SSLError):
                 # This error is raised when the website uses a legacy SSL version, which is not supported by requests

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -6,6 +6,7 @@ import json
 import os
 import ssl
 
+from common import get_user_agent
 
 class RootURLCache:
     def __init__(self, cache_file='url_cache.json'):
@@ -35,8 +36,7 @@ class RootURLCache:
         parsed_url = urlparse(url)
         root_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
         headers = {
-            # Some websites refuse the connection of automated requests, setting the User-Agent will circumvent that
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36",
+            "User-Agent": get_user_agent(),
         }
 
         if root_url not in self.cache:

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -45,12 +45,19 @@ class RootURLCache:
             except (requests.exceptions.SSLError, ssl.SSLError):
                 # This error is raised when the website uses a legacy SSL version, which is not supported by requests
                 # Retry without SSL verification
-                response = requests.get(url, headers=headers, verify=False)
+                try:
+                    response = requests.get(url, headers=headers, verify=False)
+                except Exception as e:
+                    return f"Error retrieving title: {e}"
             except Exception as e:
                 return f"Error retrieving title: {e}"
 
             soup = BeautifulSoup(response.text, 'html.parser')
-            title = soup.find('title').text
+            try:
+                title = soup.find('title').text
+            except AttributeError:
+                title = ""
+            
             self.cache[root_url] = title
             self.save_cache()
 

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -28,6 +28,9 @@ class RootURLCache:
             json.dump(self.cache, f, indent=4)
 
     def get_title(self, url):
+        if not url.startswith('http'):
+            url = "https://" + url
+
         parsed_url = urlparse(url)
         root_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
         headers = {

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -71,7 +71,7 @@ class RootURLCache:
 
         return self.cache[root_url]
 
-    def handle_exception(e):
+    def handle_exception(self, e):
         if DEBUG:
             return f"Error retrieving title: {e}"
         else:

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -50,9 +50,9 @@ class RootURLCache:
                 try:
                     response = requests.get(root_url, headers=headers, timeout=120, verify=False)
                 except Exception as e:
-                    return handle_exception(e)
+                    return self.handle_exception(e)
             except Exception as e:
-                return handle_exception(e)
+                return self.handle_exception(e)
 
             soup = BeautifulSoup(response.text, 'html.parser')
             try:

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -30,10 +30,15 @@ class RootURLCache:
     def get_title(self, url):
         parsed_url = urlparse(url)
         root_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+        headers = {
+            # Some websites refuse the connection of automated requests, setting the User-Agent will circumvent that
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36",
+        }
 
         if root_url not in self.cache:
             try:
-                response = requests.get(root_url)
+                print(root_url)
+                response = requests.get(root_url, headers=headers)
                 soup = BeautifulSoup(response.text, 'html.parser')
                 title = soup.find('title').text
                 self.cache[root_url] = title

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -41,12 +41,12 @@ class RootURLCache:
 
         if root_url not in self.cache:
             try:
-                response = requests.get(root_url, headers=headers)
+                response = requests.get(root_url, headers=headers, timeout=120)
             except (requests.exceptions.SSLError, ssl.SSLError):
                 # This error is raised when the website uses a legacy SSL version, which is not supported by requests
                 # Retry without SSL verification
                 try:
-                    response = requests.get(url, headers=headers, verify=False)
+                    response = requests.get(root_url, headers=headers, timeout=120, verify=False)
                 except Exception as e:
                     return f"Error retrieving title: {e}"
             except Exception as e:

--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -71,8 +71,8 @@ class RootURLCache:
 
         return self.cache[root_url]
 
-        def handle_exception(e):
-            if DEBUG:
-                return f"Error retrieving title: {e}"
-            else:
-                return ""
+    def handle_exception(e):
+        if DEBUG:
+            return f"Error retrieving title: {e}"
+        else:
+            return ""

--- a/html_tag_collector/collector.py
+++ b/html_tag_collector/collector.py
@@ -267,15 +267,17 @@ def parse_response(url_response):
     except (bs4.builder.ParserRejectedMarkup, AssertionError, AttributeError):
         return tags
 
+    remove_whitespace = lambda s: " ".join(s.split()).strip()
+
     if soup.title is not None and soup.title.string is not None:
-        tags["html_title"] = soup.title.string.strip()
+        tags["html_title"] = remove_whitespace(soup.title.string)
     else:
         tags["html_title"] = ""
-    tags["root_page_title"] = root_url_cache.get_title(tags["url"])
+    tags["root_page_title"] = remove_whitespace(root_url_cache.get_title(tags["url"]))
 
     meta_tag = soup.find("meta", attrs={"name": "description"})
     try:
-        tags["meta_description"] = meta_tag["content"] if meta_tag is not None else ""
+        tags["meta_description"] = remove_whitespace(meta_tag["content"]) if meta_tag is not None else ""
     except KeyError:
         tags["meta_description"] = ""
 

--- a/html_tag_collector/collector.py
+++ b/html_tag_collector/collector.py
@@ -91,7 +91,8 @@ async def run_get_response(urls):
     """
     tasks = []
     urllib3.disable_warnings()
-    session = AsyncHTMLSession(workers=100)
+    user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
+    session = AsyncHTMLSession(workers=100, browser_args=["--no-sandbox", f"--user-agent={user_agent}"])
 
     print("Retrieving HTML tags...")
     for i, url in enumerate(urls):

--- a/html_tag_collector/collector.py
+++ b/html_tag_collector/collector.py
@@ -236,7 +236,7 @@ def parse_response(url_response):
     Returns:
         list[dict]: List of dictionaries containing urls and relevant HTML tags.
     """
-    remove_whitespace = lambda s: " ".join(s.split()).strip()
+    remove_excess_whitespace = lambda s: " ".join(s.split()).strip()
     
     tags = {}
     res = url_response["response"]
@@ -244,7 +244,7 @@ def parse_response(url_response):
     tags["url"] = url_response["url"][0]
     tags["html_title"] = ""
     tags["meta_description"] = ""
-    tags["root_page_title"] = remove_whitespace(root_url_cache.get_title(tags["url"]))
+    tags["root_page_title"] = remove_excess_whitespace(root_url_cache.get_title(tags["url"]))
 
     if res is None:
         tags["http_response"] = -1
@@ -272,13 +272,13 @@ def parse_response(url_response):
         return tags
 
     if soup.title is not None and soup.title.string is not None:
-        tags["html_title"] = remove_whitespace(soup.title.string)
+        tags["html_title"] = remove_excess_whitespace(soup.title.string)
     else:
         tags["html_title"] = ""
 
     meta_tag = soup.find("meta", attrs={"name": "description"})
     try:
-        tags["meta_description"] = remove_whitespace(meta_tag["content"]) if meta_tag is not None else ""
+        tags["meta_description"] = remove_excess_whitespace(meta_tag["content"]) if meta_tag is not None else ""
     except KeyError:
         tags["meta_description"] = ""
 

--- a/html_tag_collector/collector.py
+++ b/html_tag_collector/collector.py
@@ -61,16 +61,11 @@ def process_urls(manager_list, render_javascript):
         loop.run_until_complete(future)
         results = future.result()
 
-    parsed_data = []
-    with ThreadPoolExecutor(max_workers=100) as executor:
-        print("Parsing responses...")
-        future_to_tags = [executor.submit(parse_response, url_response) for url_response in urls_and_responses]
+    urls_and_headers = []
+    print("Parsing responses...")
+    for url_response in tqdm(urls_and_responses):
+        urls_and_headers.append(parse_response(url_response))
 
-        for future in tqdm(as_completed(future_to_tags), total=len(future_to_tags)):
-            data = future.result()
-            parsed_data.append(data)
-
-    urls_and_headers = sorted(parsed_data, key=lambda d: d["index"])
     [url_headers.pop("index") for url_headers in urls_and_headers]
     header_tags_df = pl.DataFrame(urls_and_headers)
     clean_header_tags_df = header_tags_df.with_columns(pl.all().fill_null(""))

--- a/html_tag_collector/collector.py
+++ b/html_tag_collector/collector.py
@@ -369,7 +369,7 @@ if __name__ == "__main__":
     cumulative_df = process_in_batches(df, render_javascript=render_javascript)
 
     # Drop duplicate columns
-    df = df.drop(["http_response", "html_title", "meta_description", *header_tags])
+    df = df.drop(["http_response", "html_title", "meta_description", "root_page_title", *header_tags])
     # join the url/header tag df with the original df which contains the labels (order has been preserved)
     # remove duplicate rows
     out_df = df.join(cumulative_df, on="url", how="left")

--- a/html_tag_collector/collector.py
+++ b/html_tag_collector/collector.py
@@ -18,6 +18,7 @@ from bs4 import BeautifulSoup
 import polars as pl
 
 from RootURLCache import RootURLCache
+from common import get_user_agent
 
 # Define the list of header tags we want to extract
 header_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
@@ -91,8 +92,7 @@ async def run_get_response(urls):
     """
     tasks = []
     urllib3.disable_warnings()
-    user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"
-    session = AsyncHTMLSession(workers=100, browser_args=["--no-sandbox", f"--user-agent={user_agent}"])
+    session = AsyncHTMLSession(workers=100, browser_args=["--no-sandbox", f"--user-agent={get_user_agent()}"])
 
     print("Retrieving HTML tags...")
     for i, url in enumerate(urls):
@@ -117,8 +117,7 @@ async def get_response(session, url, index):
         dict(int, Response): Dictionary of the url's index value and Response object, None if an error occurred.
     """
     headers = {
-        # Some websites refuse the connection of automated requests, setting the User-Agent will circumvent that
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36",
+        "User-Agent": get_user_agent(),
         # Make sure there's no pre-mature closing of responses before a redirect completes
         "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
     }

--- a/html_tag_collector/collector.py
+++ b/html_tag_collector/collector.py
@@ -235,12 +235,15 @@ def parse_response(url_response):
     Returns:
         list[dict]: List of dictionaries containing urls and relevant HTML tags.
     """
+    remove_whitespace = lambda s: " ".join(s.split()).strip()
+    
     tags = {}
     res = url_response["response"]
     tags["index"] = url_response["index"]
     tags["url"] = url_response["url"][0]
     tags["html_title"] = ""
     tags["meta_description"] = ""
+    tags["root_page_title"] = remove_whitespace(root_url_cache.get_title(tags["url"]))
 
     if res is None:
         tags["http_response"] = -1
@@ -267,13 +270,10 @@ def parse_response(url_response):
     except (bs4.builder.ParserRejectedMarkup, AssertionError, AttributeError):
         return tags
 
-    remove_whitespace = lambda s: " ".join(s.split()).strip()
-
     if soup.title is not None and soup.title.string is not None:
         tags["html_title"] = remove_whitespace(soup.title.string)
     else:
         tags["html_title"] = ""
-    tags["root_page_title"] = remove_whitespace(root_url_cache.get_title(tags["url"]))
 
     meta_tag = soup.find("meta", attrs={"name": "description"})
     try:

--- a/html_tag_collector/common.py
+++ b/html_tag_collector/common.py
@@ -1,0 +1,9 @@
+def get_user_agent():
+    """Returns a proper user agent string to be used for requests.
+
+    Some websites refuse the connection of automated requests, setting the User-Agent will circumvent that.
+
+    Returns:
+        str: User agent string.
+    """    
+    return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36"


### PR DESCRIPTION
#### Fixes

* #56 

#### Description

* All issues outlined in #56 are fixed
* Added some additional whitespace cleanup for `html_title` and `meta_description`
* De-parallelizes the response parser, it takes a little bit longer now (usually about a minute for 200 urls) but this fixes an issue with simultaneous updating of the RootURLCache dictionary.
* Diagnosed and fixed another issue related to the render_javascript functionality, where some websites would refuse the connection due to the user agent not being set properly. This should mean we get even more accurate headers and less errors overall. 
