### PR TITLE
Mc common crawl enhancements

### DIFF
--- a/.github/workflows/common_crawler.yaml
+++ b/.github/workflows/common_crawler.yaml
@@ -25,14 +25,16 @@ jobs:
       - name: Install dependencies
         run: pip install -r common_crawler/requirements_common_crawler_action.txt
       - name: Run script
-        run: python common_crawler/main.py CC-MAIN-2023-50 *.gov police --config common_crawler/config.ini --pages 20
+        run: python common_crawler/main.py CC-MAIN-2024-10 *.gov police --config common_crawler/config.ini --pages 20
       - name: Configure Git
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-      - name: Add common_crawler cache
-        run: git add common_crawler/data/cache.json
+      - name: Add common_crawler cache and common_crawler batch_info
+        run: |
+          git add common_crawler/data/cache.json 
+          git add common_crawler/data/batch_info.csv
       - name: Commit changes
-        run: git commit -m "Update common_crawler cache"
+        run: git commit -m "Update common_crawler cache and batch_info"
       - name: Push changes
         run: git push

--- a/.github/workflows/common_crawler.yaml
+++ b/.github/workflows/common_crawler.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install dependencies
-        run: pip install common_crawler/requirements_common_crawler_action.txt
+        run: pip install -r common_crawler/requirements_common_crawler_action.txt
       - name: Run script
         run: python common_crawler/main.py CC-MAIN-2023-50 *.gov police --config common_crawler/config.ini --pages 20
       - name: Configure Git

--- a/.github/workflows/common_crawler.yaml
+++ b/.github/workflows/common_crawler.yaml
@@ -2,9 +2,7 @@ name: Common Crawler
 
 # Pull request will run every day at 1AM.
 on:
-  schedule:
-    - cron:  '0 1 * * *'
-
+  workflow_dispatch:
 env:
   # The access token enabling write access to the Huggingface Database
   HUGGINGFACE_ACCESS_TOKEN: ${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}

--- a/Tests/test_common_crawler_integration.py
+++ b/Tests/test_common_crawler_integration.py
@@ -173,7 +173,7 @@ def test_main_with_valid_args(mock_upload_file, mocker, temp_dir):
     assert row_dict['Datetime'] == '2022-12-12 12:00:00'
     assert row_dict['Keywords'] == '*.com - keyword'
     assert batch_csv_data.rows[0]['Source'] == 'Common Crawl'
-    assert batch_csv_data.rows[0]['Notes'] == 'CC-MAIN-9999-99'
+    assert batch_csv_data.rows[0]['Notes'] == 'CC-MAIN-9999-99, 2 pages'
 
     # Run main again with different arguments and no reset_cache enabled, to test persistence of cache and output files
     mock_upload_file.side_effect = validate_csvs
@@ -229,7 +229,7 @@ def test_main_with_valid_args(mock_upload_file, mocker, temp_dir):
     assert row_dict['Datetime'] == '2022-12-12 12:00:00'
     assert row_dict['Keywords'] == '*.gov - police'
     assert row_dict['Source'] == 'Common Crawl'
-    assert row_dict['Notes'] == 'CC-MAIN-0000-00'
+    assert row_dict['Notes'] == 'CC-MAIN-0000-00, 3 pages'
 
 @pytest.fixture
 def temp_dir():

--- a/Tests/test_common_crawler_integration.py
+++ b/Tests/test_common_crawler_integration.py
@@ -173,7 +173,7 @@ def test_main_with_valid_args(mock_upload_file, mocker, temp_dir):
     assert row_dict['Datetime'] == '2022-12-12 12:00:00'
     assert row_dict['Keywords'] == '*.com - keyword'
     assert batch_csv_data.rows[0]['Source'] == 'Common Crawl'
-    assert batch_csv_data.rows[0]['Notes'] == 'CC-MAIN-9999-99, 2 pages'
+    assert batch_csv_data.rows[0]['Notes'] == 'CC-MAIN-9999-99, 2 pages, starting at 1'
 
     # Run main again with different arguments and no reset_cache enabled, to test persistence of cache and output files
     mock_upload_file.side_effect = validate_csvs
@@ -229,7 +229,7 @@ def test_main_with_valid_args(mock_upload_file, mocker, temp_dir):
     assert row_dict['Datetime'] == '2022-12-12 12:00:00'
     assert row_dict['Keywords'] == '*.gov - police'
     assert row_dict['Source'] == 'Common Crawl'
-    assert row_dict['Notes'] == 'CC-MAIN-0000-00, 3 pages'
+    assert row_dict['Notes'] == 'CC-MAIN-0000-00, 3 pages, starting at 1'
 
 @pytest.fixture
 def temp_dir():

--- a/Tests/test_common_crawler_integration.py
+++ b/Tests/test_common_crawler_integration.py
@@ -3,12 +3,13 @@ import json
 import os
 import shutil
 import tempfile
+import datetime
 from unittest.mock import patch
 
 import pytest
 
 from common_crawler.csv_manager import CSVManager
-from common_crawler.main import main
+from common_crawler.main import main, BATCH_HEADERS
 from common_crawler.cache import CommonCrawlerCacheManager
 
 class CSVData:
@@ -22,22 +23,26 @@ class CSVData:
                 row_dict = dict(zip(self.headers, row))  # Convert the row to a dictionary
                 self.rows.append(row_dict)
 
-def validate_csv(directory, expected_values):
+def validate_csv(file_path, expected_values):
     """
     Validate that the CSV file contains the expected values
     Args:
-        directory:
+        file_path:
         expected_values:
 
     Returns:
 
     """
+    # Extract directory path from local_file_path
+    directory = os.path.dirname(file_path)
+    # Extract file name from local_file_path
+    file_name = os.path.basename(file_path)
+
     # Create a dictionary mirroring the expected values,
     # with the column names as keys, and all values initialized to false
     found_dict = {column: False for column in expected_values.keys()}
 
-    csv_file = get_csv_in_directory(directory)
-    path = f"{directory}/{csv_file}"
+    path = f"{directory}/{file_name}"
     csv_data = CSVData(path)
 
     for row in csv_data.rows:
@@ -46,15 +51,6 @@ def validate_csv(directory, expected_values):
                 found_dict[column] = True
 
     return all(found_dict.values())
-
-
-def get_csv_in_directory(directory):
-    # Find csv in directory and confirm there is only one
-    csv_files = [file for file in os.listdir(directory) if file.endswith('.csv')]
-    assert len(csv_files) == 1, "Multiple CSV files found in directory"
-    csv_file = csv_files[0]
-    return csv_file
-
 
 def test_cache_persistence():
     """
@@ -90,39 +86,39 @@ def test_cache_persistence():
 
 def validate_csvs(local_file_path, repo_file_path):
     # Check that the output file was created, and contains the expected data
-    assert validate_csv('test_data', {
+
+    assert validate_csv(local_file_path, {
         'url': 'http://police.com'
     }), "Output csv file does not contain expected data"
-    assert validate_csv('test_data', {
+    assert validate_csv(local_file_path, {
         'url': 'http://police.com/page2'
     }), "Output csv file does not contain expected data"
     # Additionally validate that the previous output file does not exist
-    assert not validate_csv('test_data', {
+    assert not validate_csv(local_file_path, {
         'url': 'http://keyword.com'
     }), "Output csv file does not contain expected data"
 
 def validate_csv_reset_cache(local_file_path, repo_file_path):
     # Check that the output file was created, and contains the expected data
-    assert validate_csv('test_data', {
+    assert validate_csv(local_file_path, {
         'url': 'http://keyword.com'
     }), "Output csv file does not contain expected data"
 
 
 
 @patch('util.huggingface_api_manager.HuggingFaceAPIManager.upload_file')
-def test_main_with_valid_args(mock_upload_file, mocker):
+def test_main_with_valid_args(mock_upload_file, mocker, temp_dir):
     """
     Test the main function with valid arguments
     """
 
-    # Check if the directory exists
-    if os.path.exists('test_data'):
-        # Remove the directory and all its contents
-        shutil.rmtree('test_data')
-
     # Replace the huggingface_api_manager upload_file function with one that
     # performs the validate_csvs function
     mock_upload_file.side_effect = validate_csv_reset_cache
+
+    # Main uses datetime.now(): patch this to provide a single datetime
+    mock_now = str(datetime.datetime(2022, 12, 12, 12, 0, 0))
+    mocker.patch("common_crawler.main.get_current_time", return_value=mock_now)
 
     mock_parse_args = mocker.patch('common_crawler.main.parse_args')
     mock_args = mock_parse_args.return_value
@@ -132,7 +128,7 @@ def test_main_with_valid_args(mock_upload_file, mocker):
     mock_args.pages = 2
     mock_args.output_filename = 'test_output'
     mock_args.cache_filename = 'test_cache'
-    mock_args.data_dir = 'test_data'
+    mock_args.data_dir = temp_dir
     mock_args.reset_cache = True
 
     # Mock the CommonCrawler to avoid actual web requests
@@ -158,12 +154,26 @@ def test_main_with_valid_args(mock_upload_file, mocker):
 
 
     # Check that the cache file was created, and contains the expected data
-    with open('test_data/test_cache.json', 'r') as file:
+    with open(f'{temp_dir}/test_cache.json', 'r') as file:
         cache = json.load(file)
         assert 'CC-MAIN-9999-99' in cache
         assert '*.com' in cache['CC-MAIN-9999-99']
         assert 'keyword' in cache['CC-MAIN-9999-99']['*.com']
         assert cache['CC-MAIN-9999-99']['*.com']['keyword'] == 2
+
+    # Check that batch file exists
+    batch_csv_data = CSVData(
+        f"{temp_dir}/batch_info.csv"
+    )
+    # Check headers
+    assert batch_csv_data.headers == BATCH_HEADERS
+    # Check first row
+    row_dict = batch_csv_data.rows[0]
+    assert row_dict['Count'] == '1'
+    assert row_dict['Datetime'] == '2022-12-12 12:00:00'
+    assert row_dict['Keywords'] == '*.com - keyword'
+    assert batch_csv_data.rows[0]['Source'] == 'Common Crawl'
+    assert batch_csv_data.rows[0]['Notes'] == 'CC-MAIN-9999-99'
 
     # Run main again with different arguments and no reset_cache enabled, to test persistence of cache and output files
     mock_upload_file.side_effect = validate_csvs
@@ -194,7 +204,7 @@ def test_main_with_valid_args(mock_upload_file, mocker):
     main()
 
     # Check that the cache file was created, and contains the expected data
-    with open('test_data/test_cache.json', 'r') as file:
+    with open(f'{temp_dir}/test_cache.json', 'r') as file:
         cache = json.load(file)
         # Check the original data persists
         assert 'CC-MAIN-9999-99' in cache
@@ -207,17 +217,19 @@ def test_main_with_valid_args(mock_upload_file, mocker):
         assert 'police' in cache['CC-MAIN-0000-00']['*.gov']
         assert cache['CC-MAIN-0000-00']['*.gov']['police'] == 3
 
-    # Clean up the test files
-    if os.path.exists('test_data'):
-        # Remove the directory and all its contents
-        shutil.rmtree('test_data')
-
-@pytest.fixture
-def temp_file():
-    # Create a temporary file which is deleted at the end of the test
-    yield 'temp_file'
-
-    os.remove('temp_file.csv')
+    # Check that batch file exists
+    batch_csv_data = CSVData(
+        f"{temp_dir}/batch_info.csv"
+    )
+    # Check headers
+    assert batch_csv_data.headers == BATCH_HEADERS
+    # Check second row
+    row_dict = batch_csv_data.rows[1]
+    assert row_dict['Count'] == '2'
+    assert row_dict['Datetime'] == '2022-12-12 12:00:00'
+    assert row_dict['Keywords'] == '*.gov - police'
+    assert row_dict['Source'] == 'Common Crawl'
+    assert row_dict['Notes'] == 'CC-MAIN-0000-00'
 
 @pytest.fixture
 def temp_dir():
@@ -228,7 +240,7 @@ def temp_dir():
         shutil.rmtree(dirpath)
 
 
-def test_csv_manager(temp_file, temp_dir):
+def test_csv_manager(temp_dir):
     """
     Confirm functionality of CSV manager, including:
         That headers are properly defined
@@ -236,9 +248,11 @@ def test_csv_manager(temp_file, temp_dir):
         That CSV Manager properly either creates a file or appends to a file if it already exists
     Returns:
     """
+    temp_file = 'temp_file'
+    headers = ['header1', 'header2', 'header3']
     csv_manager = CSVManager(
         file_name=temp_file,
-        headers=['header1', 'header2', 'header3'],
+        headers=headers,
         directory=temp_dir
     )
     # Add 2 rows of data
@@ -249,3 +263,19 @@ def test_csv_manager(temp_file, temp_dir):
     csv_manager.add_rows(rows)
 
     # Check file has two rows not including header
+    temp_file_path = csv_manager.file_path
+    csv_data = CSVData(temp_file_path)
+    assert csv_data.headers == headers, "CSV file does not contain the expected headers"
+    assert len(csv_data.rows) == 2, "CSV file does not contain the expected number of rows"
+
+    # Re-initialize CSVManager, add an additional row, and check that there are now three rows
+    csv_manager = CSVManager(
+        file_name=temp_file,
+        headers=headers,
+        directory=temp_dir
+    )
+    csv_manager.add_rows([['data7', 'data8', 'data9']])
+    # Check file has three rows not including header
+    csv_data = CSVData(temp_file_path)
+    assert csv_data.headers == headers, "CSV file does not contain the expected headers"
+    assert len(csv_data.rows) == 3, "CSV file does not contain the expected number of rows"

--- a/common_crawler/README.md
+++ b/common_crawler/README.md
@@ -4,6 +4,8 @@ This module interfaces with the Common Crawl dataset to extract urls.
 
 ## Installation
 
+Python Version Required: 3.11
+
 To install all necessary dependencies, run the following command from the root directory:
 
 ```bash
@@ -25,7 +27,7 @@ and ensure you have write access to https://huggingface.co/PDAP .
 
 Run the following script from the root directory
 ```bash
-python common_crawler/main.py CC-MAIN-2023-50 *.gov police --config common_crawler/config.ini --pages 2
+python common_crawler/main.py CC-MAIN-2023-50 '*.gov' police --config common_crawler/config.ini --pages 2
 ```
 
 This example will crawl a single page (typically 15000 records) of the Common Crawl dataset with ID `CC-MAIN-2023-50` 
@@ -42,7 +44,7 @@ This csv file contains both the url and the parameters used to query it.
 ### Parameters
 
 - **common_crawl_id**: Required. Specifies the Common Crawl Index to perform the search on.
-- **url**: Required. Specifies the domain URL to query. Wildcard characters such as * can be used to expand the search.
+- **url**: Required. Specifies the domain URL to query. Wildcard characters such as * can be used to expand the search. Note that the query must be contained within quotes (as in '*.gov') to prevent misinterpretation of wildcards
 - **search_term**: Required. Specifies keyword within the url to search for.
 - **-c or --config**: Optional. Specifies the configuration file to use. The default value is config.ini.
 - **-p or --pages**: Optional. Specifies the number of pages to search. The default value is 1.

--- a/common_crawler/crawler.py
+++ b/common_crawler/crawler.py
@@ -19,7 +19,7 @@ This module contains classes for managing a cache of Common Crawl search results
 @dataclass
 class CommonCrawlResult:
     last_page_search: int
-    url_results: list
+    url_results: list[str]
 
 
 class CommonCrawlerManager:

--- a/common_crawler/csv_manager.py
+++ b/common_crawler/csv_manager.py
@@ -10,34 +10,43 @@ class CSVManager:
     Creates the file if it doesn't exist, and provides a method for adding new rows.
     """
 
-    def __init__(self, file_name: str = 'urls', directory=None):
+    def __init__(
+            self,
+            file_name: str,
+            headers: list[str],
+            directory=None
+    ):
         self.file_path = get_file_path(f"{file_name}.csv", directory)
+        self.headers = headers
         if not os.path.exists(self.file_path):
             self.initialize_file()
 
-    def add_row(self, url: str):
+    def add_row(self, row_values: list[str]):
         """
         Appends a new row of data to the CSV.
-        Data should be a list or tuple in the format:
-        (index, search_term, keyword, page, url)
+        Args:
+            row_values: list of values to add to the csv, in order of their inclusion in the list
         """
+        if isinstance(row_values, str):
+            # Single values must be converted to a list format
+             row_values = [row_values]
         try:
             with open(self.file_path, mode='a', newline='', encoding='utf-8') as file:
                 writer = csv.writer(file)
-                writer.writerow([url])
+                writer.writerow(row_values)
         except Exception as e:
             print(f"An error occurred while trying to write to {self.file_path}: {e}")
 
-    def add_rows(self, results: list) -> None:
+    def add_rows(self, results: list[list[str]]) -> None:
         """
-        Appends multiple rows of data to the CSV.
+        Appends multiple rows of data to the CSV as a list of lists of strings.
         Args:
-            results: list[UrlResults] - a list of UrlResults named tuples
-        Returns:
+            results: list[list[str] - a list of lists of strings, each inner list representing a row
+        Returns: None
         """
         for result in results:
             self.add_row(
-                url=result
+                result
             )
         print(f"{len(results)} URLs written to {self.file_path}")
 
@@ -47,9 +56,9 @@ class CSVManager:
         If the file doesn't exist, it creates it with the header row.
         If the file does exist, it empties it, leaving only the header row.
         """
-        with open(self.file_path, mode='w', newline='', encoding='utf-8') as file:
+        with open(self.file_path, mode='a', newline='', encoding='utf-8') as file:
             writer = csv.writer(file)
-            writer.writerow(['url'])
+            writer.writerow(self.headers)
         print(f"CSV file initialized at {self.file_path}")
 
     def delete_file(self):

--- a/common_crawler/csv_manager.py
+++ b/common_crawler/csv_manager.py
@@ -21,7 +21,7 @@ class CSVManager:
         if not os.path.exists(self.file_path):
             self.initialize_file()
 
-    def add_row(self, row_values: list[str]):
+    def add_row(self, row_values: list[str] | tuple[str]):
         """
         Appends a new row of data to the CSV.
         Args:
@@ -54,11 +54,20 @@ class CSVManager:
         """
         Initializes the CSV file.
         If the file doesn't exist, it creates it with the header row.
-        If the file does exist, it empties it, leaving only the header row.
         """
-        with open(self.file_path, mode='a', newline='', encoding='utf-8') as file:
-            writer = csv.writer(file)
-            writer.writerow(self.headers)
+        # check if file exists
+        file_exists = os.path.isfile(self.file_path)
+
+        if not file_exists:
+            with open(self.file_path, mode='a', newline='', encoding='utf-8') as file:
+                writer = csv.writer(file)
+                writer.writerow(self.headers)
+        else:
+            # Open and check that headers match
+            with open(self.file_path, mode='r', encoding='utf-8') as file:
+                header_row = next(csv.reader(file))
+                if header_row != self.headers:
+                    raise ValueError(f"Header row in {self.file_path} does not match expected headers")
         print(f"CSV file initialized at {self.file_path}")
 
     def delete_file(self):

--- a/common_crawler/main.py
+++ b/common_crawler/main.py
@@ -83,7 +83,7 @@ def main():
             source="Common Crawl",
             count=str(len(common_crawl_result.url_results)),
             keywords=f"{args.url} - {args.keyword}",
-            notes=f"{args.common_crawl_id}, {args.pages} pages"
+            notes=f"{args.common_crawl_id}, {args.pages} pages, starting at {last_page + 1}"
         )
         add_batch_info_to_csv(batch_info, args.data_dir)
     except ValueError as e:

--- a/common_crawler/main.py
+++ b/common_crawler/main.py
@@ -83,7 +83,7 @@ def main():
             source="Common Crawl",
             count=str(len(common_crawl_result.url_results)),
             keywords=f"{args.url} - {args.keyword}",
-            notes=args.common_crawl_id
+            notes=f"{args.common_crawl_id}, {args.pages} pages"
         )
         add_batch_info_to_csv(batch_info, args.data_dir)
     except ValueError as e:

--- a/common_crawler/main.py
+++ b/common_crawler/main.py
@@ -80,6 +80,7 @@ def handle_csv_and_upload(
     """
     csv_manager = CSVManager(
         file_name=f"{args.output_filename}_{get_filename_friendly_timestamp()}",
+        headers=['url'],
         directory=args.data_dir
     )
     csv_manager.add_rows(common_crawl_result.url_results)


### PR DESCRIPTION
#### Fixes

#66 - Common Crawler Enhancements 

#### Description

This enhances the `common_crawler` module by adding batch logging. Additionally, it modifies the Github Actions yaml file to only run on manual command, rather than automatically.

#### Testing

Run the following unit and integration test scripts located in the `tests` directory.
1. `test_common_crawler_integration.py`
2. `test_common_crawler_unit.py`
3. `test_util_unit.py`

Additionally, follow the instructions in `common_crawler/README.md` to manually run the script and confirm functionality. The script, once completed, should yield the following results:
1. If relevant URLs were found, the new relevant URLs will be located in the aforementioned HuggingFace dataset.
2. The cache should be updated now such that, if the same command is run, the crawler will resume at the page after the last page crawled in the previous execution of `main.py`
3. The `batch_info.csv` file in the `data` directory of `common_crawler` should provide information about the batch, including the number of urls uploaded, the source, and additional relevant details