### PR TITLE
add flag for installing requirements

### DIFF
--- a/.github/workflows/common_crawler.yaml
+++ b/.github/workflows/common_crawler.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
       - name: Install dependencies
-        run: pip install common_crawler/requirements_common_crawler_action.txt
+        run: pip install -r common_crawler/requirements_common_crawler_action.txt
       - name: Run script
         run: python common_crawler/main.py CC-MAIN-2023-50 *.gov police --config common_crawler/config.ini --pages 20
       - name: Configure Git


### PR DESCRIPTION
The lack of this flag on pip install is causing the install to fail on the Github action