### PR TITLE
mc_revise_pr_type_checking_and_linting

### DIFF
--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -19,4 +19,4 @@ jobs:
         uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          fail-on-error: false
+          fail_on_error: false

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -19,4 +19,4 @@ jobs:
         uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          fail_on_error: false
+          level: warning

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -35,4 +35,5 @@ jobs:
       env:
         GITHUB_BASE_REF: ${{ github.base_ref }}
         GITHUB_HEAD_REF: ${{ github.head_ref }}
+        HEAD_REPO_PATH: ${{ github.workspace }}/head_repo
       working-directory: ${{ github.workspace }}/head_repo

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -35,4 +35,4 @@ jobs:
       env:
         GITHUB_BASE_REF: ${{ github.base_ref }}
         GITHUB_HEAD_REF: ${{ github.head_ref }}
-        HEAD_REPO_PATH: ${{ github.workspace }}/head_repo  # Use this environment variable to refer to the checked-out fork
+      working-directory: ${{ github.workspace }}/head_repo

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -15,7 +15,6 @@ jobs:
           python-version: "3.11"
       - run: pip install flake8 flake8-docstrings flake8-simplify flake8-unused-arguments flake8-annotations
       - name: flake8 Lint with Reviewdog
-        continue-on-error: true
         uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -19,3 +19,4 @@ jobs:
         uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: false

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -1,6 +1,6 @@
 name: Python Checks
 
-on: [pull_request]
+on: [push, pull_request]
 
 permissions:
   issues: write

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -11,8 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint
     steps:
-      - uses: actions/checkout@v4
-      - uses: TrueBrain/actions-flake8@v2
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
         with:
-          only_warn: 1
+          python-version: "3.11"
+      - name: flake8 Lint
+        uses: py-actions/flake8@v2
+        with:
           plugins: "flake8-docstrings"

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -3,37 +3,12 @@ name: Python Checks
 on: [pull_request]
 
 jobs:
-  type_and_docstring_check:
+  flake8-lint:
     runs-on: ubuntu-latest
+    name: Lint
     steps:
-    - name: Checkout base branch
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.base_ref }}
-        fetch-depth: 0
-
-    - name: Fetch head branch from fork
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        fetch-depth: 0
-        path: 'head_repo'  # This checks out the forked repo into a separate directory
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.11'
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install mypy pydocstyle
-
-    - name: Find and Check Modified Python Files
-      run: python util/type_and_docstyle_checking.py
-      env:
-        GITHUB_BASE_REF: ${{ github.base_ref }}
-        GITHUB_HEAD_REF: ${{ github.head_ref }}
-        HEAD_REPO_PATH: ${{ github.workspace }}/head_repo
-      working-directory: ${{ github.workspace }}/head_repo
+      - uses: actions/checkout@v4
+      - uses: TrueBrain/actions-flake8@v2
+        with:
+          only_warn: 1
+          plugins: "flake8-docstrings"

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -2,6 +2,10 @@ name: Python Checks
 
 on: [pull_request]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   flake8-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -28,28 +28,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install mypy pydocstyle
 
-    - name: Find modified Python files
-      run: |
-        echo "MODIFIED_FILES=$(git diff --name-only refs/remotes/origin/${{ github.base_ref }} $(git merge-base refs/remotes/origin/${{ github.base_ref }} refs/remotes/origin/${{ github.head_ref }}) | grep '\.py$')" >> $GITHUB_ENV
-
-    - name: Run mypy
-      if: env.MODIFIED_FILES != ''
-      run: |
-        echo "${{ env.MODIFIED_FILES }}" | xargs mypy --ignore-missing-imports --disallow-untyped-defs 
-        echo "mypy_exit_code=$?" >> $GITHUB_ENV
-      continue-on-error: true
-
-    - name: Run pydocstyle
-      if: env.MODIFIED_FILES != ''
-      run: |
-        echo "${{ env.MODIFIED_FILES }}" | xargs pydocstyle
-        echo "pydocstyle_exit_code=$?" >> $GITHUB_ENV
-      continue-on-error: true
-
-    - name: Check errors
-      if: env.MODIFIED_FILES != ''
-      run: |
-        if [ "$mypy_exit_code" != "0" ] || [ "$pydocstyle_exit_code" != "0" ]; then
-          echo "Errors detected in mypy or pydocstyle"
-          exit 1
-        fi
+    - name: Find and Check Modified Python Files
+      run: python util/type_and_docstyle_checking.py
+      env:
+        GITHUB_BASE_REF: ${{ github.base_ref }}
+        GITHUB_HEAD_REF: ${{ github.head_ref }}

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install flake8 flake8-docstrings flake8-simplify flake8-unused-arguments flake8-annotations
-      - name: flake8 Lint
+      - name: flake8 Lint with Reviewdog
         continue-on-error: true
         uses: reviewdog/action-flake8@v3
         with:

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -2,21 +2,23 @@ name: Python Checks
 
 on: [pull_request]
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   type_and_docstring_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout base branch
+      uses: actions/checkout@v2
       with:
+        ref: ${{ github.base_ref }}
         fetch-depth: 0
-    - name: Fetch base and head branches
-      run: |
-        git fetch --no-tags --depth=1 origin +${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-        git fetch --no-tags --depth=1 origin +${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+
+    - name: Fetch head branch from fork
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        fetch-depth: 0
+        path: 'head_repo'  # This checks out the forked repo into a separate directory
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -33,3 +35,4 @@ jobs:
       env:
         GITHUB_BASE_REF: ${{ github.base_ref }}
         GITHUB_HEAD_REF: ${{ github.head_ref }}
+        HEAD_REPO_PATH: ${{ github.workspace }}/head_repo  # Use this environment variable to refer to the checked-out fork

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -8,9 +8,9 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - run: pip install flake8 flake8-docstrings flake8-simplify flake8-unused-arguments flake8-annotations

--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -1,10 +1,6 @@
-name: Python Checks
+name: flake8 Lint
 
-on: [push, pull_request]
-
-permissions:
-  issues: write
-  pull-requests: write
+on: [pull_request]
 
 jobs:
   flake8-lint:
@@ -12,12 +8,14 @@ jobs:
     name: Lint
     steps:
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Set up Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         with:
           python-version: "3.11"
+      - run: pip install flake8 flake8-docstrings flake8-simplify flake8-unused-arguments flake8-annotations
       - name: flake8 Lint
-        uses: py-actions/flake8@v2
+        continue-on-error: true
+        uses: reviewdog/action-flake8@v3
         with:
-          plugins: "flake8-docstrings"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Tests/test_type_and_docstyle_checking.py
+++ b/Tests/test_type_and_docstyle_checking.py
@@ -64,21 +64,6 @@ def test_check_files_no_modification(mock_subprocess_run, capsys):
     assert "No Python files were modified." in captured.out
 
 
-def test_check_files_with_errors(mock_subprocess_run, capsys):
-    """Test check_files function when errors are found."""
-    mock_subprocess_run.side_effect = [
-        Mock(stdout="script1.py script2.py", stderr=''),
-        Mock(stdout="error: issue found in script1.py", stderr=''),
-        Mock(stdout="", stderr='')
-    ]
-    with pytest.raises(SystemExit) as e:
-        check_files(["script1.py", "script2.py"])
-    assert e.type == SystemExit
-    assert e.value.code == 1
-    captured = capsys.readouterr()
-    assert "Errors detected in mypy or pydocstyle" in captured.out
-
-
 def create_temp_py_file(content: str, file_name: str):
     """Helper function to create a temporary Python file with given content."""
     with open(f"{file_name}.py", 'w') as f:

--- a/Tests/test_type_and_docstyle_checking.py
+++ b/Tests/test_type_and_docstyle_checking.py
@@ -1,20 +1,18 @@
 import os
-import tempfile
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from util.type_and_docstyle_checking import (run_command, find_modified_python_files,
                                              check_files, has_errors)
 
 # Example content for testing subprocess and os functionality
 modified_files_output = "script1.py\nscript2.py"
-mypy_output = "Success: no issues found in 2 source files"
-pydocstyle_output = ""
 
 def is_tool_installed(name):
     """Check whether `name` is on PATH and marked as executable."""
     from shutil import which
     return which(name) is not None
+
 
 @pytest.fixture(scope="session", autouse=True)
 def check_dependencies():
@@ -24,6 +22,7 @@ def check_dependencies():
     if missing_tools:
         pytest.fail(f"Missing tools required for tests: {', '.join(missing_tools)}", pytrace=False)
 
+
 @pytest.fixture
 def mock_subprocess_run(mocker):
     """Mock for subprocess.run."""
@@ -31,10 +30,12 @@ def mock_subprocess_run(mocker):
     mock.return_value = Mock(stdout=modified_files_output, stderr='')
     return mock
 
+
 @pytest.fixture
 def mock_os_getenv(mocker):
     """Mock for os.getenv."""
     mocker.patch('os.getenv', return_value="fake_ref")
+
 
 def test_run_command(mock_subprocess_run):
     """Test run_command function."""
@@ -42,27 +43,18 @@ def test_run_command(mock_subprocess_run):
     assert output == "script1.py\nscript2.py"
     mock_subprocess_run.assert_called_once_with("echo Hello", text=True, shell=True, capture_output=True)
 
+
 def test_find_modified_python_files(mock_subprocess_run, mock_os_getenv):
     """Test finding modified Python files."""
     files = find_modified_python_files()
     assert files == ["script1.py", "script2.py"]
 
-def test_run_mypy(mock_subprocess_run):
-    """Test running mypy."""
-    mock_subprocess_run.return_value.stdout = mypy_output
-    result = run_mypy(["script1.py", "script2.py"])
-    assert "no issues found" in result
-
-def test_run_pydocstyle(mock_subprocess_run):
-    """Test running pydocstyle."""
-    mock_subprocess_run.return_value.stdout = pydocstyle_output
-    result = run_pydocstyle(["script1.py", "script2.py"])
-    assert result == ""
 
 def test_has_errors():
     """Test error detection."""
-    assert not has_errors(mypy_output)
+    assert not has_errors("Success: no issues found in 2 source files")
     assert has_errors("error: failed to do something")
+
 
 def test_check_files_no_modification(mock_subprocess_run, capsys):
     """Test check_files with no files modified."""
@@ -70,6 +62,7 @@ def test_check_files_no_modification(mock_subprocess_run, capsys):
     check_files([])
     captured = capsys.readouterr()
     assert "No Python files were modified." in captured.out
+
 
 def test_check_files_with_errors(mock_subprocess_run, capsys):
     """Test check_files function when errors are found."""
@@ -86,12 +79,12 @@ def test_check_files_with_errors(mock_subprocess_run, capsys):
     assert "Errors detected in mypy or pydocstyle" in captured.out
 
 
-
 def create_temp_py_file(content: str, file_name: str):
     """Helper function to create a temporary Python file with given content."""
     with open(f"{file_name}.py", 'w') as f:
         f.write(content)
     return f.name
+
 
 @pytest.fixture
 def temp_python_files():
@@ -99,7 +92,7 @@ def temp_python_files():
     # This file will have a type hint issue
     mypy_file = create_temp_py_file(
         content="""
-def test_func(x):
+def test_func(x: int) -> int:
     return x + 1
                 """,
         file_name="mypy_file"
@@ -108,8 +101,9 @@ def test_func(x):
     # This file will have a docstring style issue
     pydocstyle_file = create_temp_py_file(
         content="""
+\"\"\"This is a module docstring\"\"\"
 def test_func():
-    \"\"\"This is a docstring\"\"\"
+    \"\"\"This is a function docstring\"\"\"
     return
             """,
         file_name="pydocstyle_file"
@@ -119,12 +113,14 @@ def test_func():
     os.unlink(mypy_file)  # Clean up files after test
     os.unlink(pydocstyle_file)
 
+
 def test_mypy_and_pydocstyle_issues(temp_python_files):
-    check_files(temp_python_files)
-    # # Run mypy and check for errors
-    # mypy_result = run_mypy(temp_python_files)
-    # assert "error:" in mypy_result
-    #
-    # # Run pydocstyle and check for errors
-    # pydocstyle_result = run_pydocstyle(temp_python_files)
-    # assert "D400" in pydocstyle_result  # Example check for a specific pydocstyle error code
+    mypy_errors, pydocstyle_errors = check_files(temp_python_files)
+    assert len(mypy_errors) > 0
+    assert len(pydocstyle_errors) > 0
+
+    # Check that each set of errors does not include the file designed to be compliant
+    for error in pydocstyle_errors:
+        assert 'pydocstyle_file' not in error
+    for error in mypy_errors:
+        assert 'mypy_file' not in error

--- a/Tests/test_type_and_docstyle_checking.py
+++ b/Tests/test_type_and_docstyle_checking.py
@@ -1,0 +1,130 @@
+import os
+import tempfile
+
+import pytest
+from unittest.mock import Mock, patch
+from util.type_and_docstyle_checking import (run_command, find_modified_python_files,
+                                             check_files, has_errors)
+
+# Example content for testing subprocess and os functionality
+modified_files_output = "script1.py\nscript2.py"
+mypy_output = "Success: no issues found in 2 source files"
+pydocstyle_output = ""
+
+def is_tool_installed(name):
+    """Check whether `name` is on PATH and marked as executable."""
+    from shutil import which
+    return which(name) is not None
+
+@pytest.fixture(scope="session", autouse=True)
+def check_dependencies():
+    """Ensure that all necessary dependencies are installed."""
+    tools = ["mypy", "pydocstyle"]
+    missing_tools = [tool for tool in tools if not is_tool_installed(tool)]
+    if missing_tools:
+        pytest.fail(f"Missing tools required for tests: {', '.join(missing_tools)}", pytrace=False)
+
+@pytest.fixture
+def mock_subprocess_run(mocker):
+    """Mock for subprocess.run."""
+    mock = mocker.patch('subprocess.run')
+    mock.return_value = Mock(stdout=modified_files_output, stderr='')
+    return mock
+
+@pytest.fixture
+def mock_os_getenv(mocker):
+    """Mock for os.getenv."""
+    mocker.patch('os.getenv', return_value="fake_ref")
+
+def test_run_command(mock_subprocess_run):
+    """Test run_command function."""
+    output = run_command("echo Hello")
+    assert output == "script1.py\nscript2.py"
+    mock_subprocess_run.assert_called_once_with("echo Hello", text=True, shell=True, capture_output=True)
+
+def test_find_modified_python_files(mock_subprocess_run, mock_os_getenv):
+    """Test finding modified Python files."""
+    files = find_modified_python_files()
+    assert files == ["script1.py", "script2.py"]
+
+def test_run_mypy(mock_subprocess_run):
+    """Test running mypy."""
+    mock_subprocess_run.return_value.stdout = mypy_output
+    result = run_mypy(["script1.py", "script2.py"])
+    assert "no issues found" in result
+
+def test_run_pydocstyle(mock_subprocess_run):
+    """Test running pydocstyle."""
+    mock_subprocess_run.return_value.stdout = pydocstyle_output
+    result = run_pydocstyle(["script1.py", "script2.py"])
+    assert result == ""
+
+def test_has_errors():
+    """Test error detection."""
+    assert not has_errors(mypy_output)
+    assert has_errors("error: failed to do something")
+
+def test_check_files_no_modification(mock_subprocess_run, capsys):
+    """Test check_files with no files modified."""
+    mock_subprocess_run.return_value.stdout = ""
+    check_files([])
+    captured = capsys.readouterr()
+    assert "No Python files were modified." in captured.out
+
+def test_check_files_with_errors(mock_subprocess_run, capsys):
+    """Test check_files function when errors are found."""
+    mock_subprocess_run.side_effect = [
+        Mock(stdout="script1.py script2.py", stderr=''),
+        Mock(stdout="error: issue found in script1.py", stderr=''),
+        Mock(stdout="", stderr='')
+    ]
+    with pytest.raises(SystemExit) as e:
+        check_files(["script1.py", "script2.py"])
+    assert e.type == SystemExit
+    assert e.value.code == 1
+    captured = capsys.readouterr()
+    assert "Errors detected in mypy or pydocstyle" in captured.out
+
+
+
+def create_temp_py_file(content: str, file_name: str):
+    """Helper function to create a temporary Python file with given content."""
+    with open(f"{file_name}.py", 'w') as f:
+        f.write(content)
+    return f.name
+
+@pytest.fixture
+def temp_python_files():
+    """Fixture to create Python files with deliberate mypy and pydocstyle issues."""
+    # This file will have a type hint issue
+    mypy_file = create_temp_py_file(
+        content="""
+def test_func(x):
+    return x + 1
+                """,
+        file_name="mypy_file"
+    )
+
+    # This file will have a docstring style issue
+    pydocstyle_file = create_temp_py_file(
+        content="""
+def test_func():
+    \"\"\"This is a docstring\"\"\"
+    return
+            """,
+        file_name="pydocstyle_file"
+    )
+
+    yield [mypy_file, pydocstyle_file]  # Provide the file paths to the test
+    os.unlink(mypy_file)  # Clean up files after test
+    os.unlink(pydocstyle_file)
+
+def test_mypy_and_pydocstyle_issues(temp_python_files):
+    check_files(temp_python_files)
+    # # Run mypy and check for errors
+    # mypy_result = run_mypy(temp_python_files)
+    # assert "error:" in mypy_result
+    #
+    # # Run pydocstyle and check for errors
+    # pydocstyle_result = run_pydocstyle(temp_python_files)
+    # assert "D400" in pydocstyle_result  # Example check for a specific pydocstyle error code

--- a/util/miscellaneous_functions.py
+++ b/util/miscellaneous_functions.py
@@ -25,6 +25,25 @@ def create_directories_if_not_exist(file_path: str):
         print(f"Creating directory: {directory}")
         os.makedirs(directory)
 
+def get_project_root() -> Path:
+    """
+    Returns the path to the project root as a Path object by searching for a marker.
+    Returns:
+
+    """
+    # Define the root markers that signify the root directory of the project
+    root_markers = ['.git']  # Add more markers as needed
+    # Start from the current file's directory
+    current_dir = Path(__file__).resolve().parent
+    while current_dir != current_dir.parent:  # Check if we've reached the root of the filesystem
+        if any((current_dir / marker).exists() for marker in root_markers):
+            # If a root marker is found, return this directory as a Path object
+            return current_dir
+        # Move up one directory level
+        current_dir = current_dir.parent
+    raise FileNotFoundError("Project root not found.")
+
+
 
 def get_file_path(file_name: str, directory: str = None) -> Path:
     """

--- a/util/miscellaneous_functions.py
+++ b/util/miscellaneous_functions.py
@@ -73,3 +73,14 @@ def get_file_path(file_name: str, directory: str = None) -> Path:
     create_directories_if_not_exist(full_path)
 
     return Path(full_path)
+
+def print_header(text: str) -> None:
+    """
+    Prints a header-type string, encapsulated by borders
+    Args:
+        text: The text to be printed
+
+    Returns:
+    """
+    border = "=" * len(text)
+    print(f"{border}\n{text}\n{border}")

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -47,12 +47,17 @@ def find_modified_python_files() -> list[str]:
     """Find modified Python files between the base and head branches with enhanced debugging."""
     base_ref = os.getenv('GITHUB_BASE_REF')
     head_ref = os.getenv('GITHUB_HEAD_REF')
+    head_repo_path = os.getenv('HEAD_REPO_PATH')
 
     if not base_ref or not head_ref:
-        print("Environment variables GITHUB_BASE_REF or GITHUB_HEAD_REF are not set.")
+        print("Required environment variables are not set.")
         return []
 
-    command_to_run = f"git diff --name-only origin/{base_ref} $(git merge-base origin/{base_ref} origin/{head_ref}) | grep '\.py$'"
+    # Check if head repo is a fork
+    if head_repo_path:
+        head_ref = f"{head_repo_path}/{head_ref}"
+
+    command_to_run = f"git diff --name-only origin/{base_ref} $(git merge-base origin/{base_ref} {head_ref}) | grep '\.py$'"
 
     print(f"Running command: {command_to_run}")
     modified_files_raw = run_command(command_to_run)

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -42,6 +42,8 @@ def run_command(command: str) -> str:
     except subprocess.CalledProcessError as e:
         print(f"Command failed with error {e.returncode}")
         print(f"Error output: {e.stderr}")
+        if e.stdout:  # Check if there is any standard output despite the error
+            print(f"Standard Output: {e.stdout}")
         return ""
 
 def find_modified_python_files() -> list[str]:

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -1,15 +1,32 @@
+"""
+This module contains the functionality for
+running type and docstyle checking on the repository
+"""
+
+import re
 import subprocess
 import os
 
-import pytest
+from util.miscellaneous_functions import get_project_root
 
 MYPY_COMMAND = 'mypy --ignore-missing-imports --disallow-untyped-defs '
-PYDOCSTYLE_COMMAND = 'pydocstyle '
 
-ERROR_KEYWORD = "error"
+MYPY_ERROR_KEYWORD = "error"
+PYDOCSTYLE_ERROR_KEYWORD = "missing"
 
-def find_pydocstyle_config():
 
+def find_pydocstyle_config() -> str:
+    """
+    Find the .pydocstyle config file, located at the root of the repository
+    and return the --config argument along with the path
+    """
+    root_path = get_project_root()
+    config_file = os.path.join(root_path, ".pydocstyle")
+    if os.path.exists(config_file):
+        return f"--config={config_file} "
+
+
+PYDOCSTYLE_COMMAND = 'pydocstyle ' + find_pydocstyle_config()
 
 
 def run_command(command: str) -> str:
@@ -41,11 +58,8 @@ def find_modified_python_files() -> list[str]:
     return modified_files
 
 
-def get_file_string(modified_files: list[str]) -> str:
-    return '\'' + "\' \'".join(modified_files) + '\''
-
-
-def run_and_get_errored_outputs(files_to_check: list[str], command: str):
+def run_and_get_errored_outputs(files_to_check: list[str], command: str) -> list[str]:
+    """Run a given command on the specified files and return the outputs, if they include errors"""
     errored_outputs = []
     for file_to_check in files_to_check:
         output = run_command(command + ' ' + file_to_check)
@@ -53,30 +67,41 @@ def run_and_get_errored_outputs(files_to_check: list[str], command: str):
             errored_outputs.append(output)
     return errored_outputs
 
-def has_errors(output):
-    return ERROR_KEYWORD in output.lower()
+
+def has_errors(output: str) -> bool:
+    """Checks for specific keywords to indicate the presence of errors"""
+    return MYPY_ERROR_KEYWORD in output.lower() or PYDOCSTYLE_ERROR_KEYWORD in output.lower()
 
 
-def check_files(files_to_check: list[str]):
+def check_files(files_to_check: list[str]) -> tuple[list[str], list[str]]:
+    """
+    Checks the specified files to see if they contain mypy or pydocstyle errors
+    Returns those errors if they exist
+    """
     if files_to_check:
-
-        mypy_outputs = run_and_get_errored_outputs(files_to_check, MYPY_COMMAND)
-        print("Mypy Results:\n")
-        for output in mypy_outputs:
-            output = output.replace('\nFound 1 error in 1 file (checked 1 source file)', '')
-            print(output)
-        pydocstyle_outputs = run_and_get_errored_outputs(files_to_check, PYDOCSTYLE_COMMAND)
-        print("Pydocstyle Results:\n")
-        for output in pydocstyle_outputs:
-            print(output)
-
-        # if has_errors(mypy_result) or has_errors(pydocstyle_result):
-        #     print("Errors detected in mypy or pydocstyle")
-        #     exit(1)
+        mypy_errors = run_and_get_errored_outputs(files_to_check, MYPY_COMMAND)
+        pydocstyle_errors = run_and_get_errored_outputs(files_to_check, PYDOCSTYLE_COMMAND)
+        return mypy_errors, pydocstyle_errors
     else:
         print("No Python files were modified.")
+        return [], []
+
+
+def announce_errors(mypy_errors: list[str], pydocstyle_errors: list[str]):
+    """Announce errors if present"""
+    print("\nMYPY RESULTS:\n")
+    for output in mypy_errors:
+        output = re.sub(r'\nFound \d+ errors* in 1 file \(checked 1 source file\)', '', output)
+        print(output)
+    print("\nPYDOCSTYLE RESULTS:\n")
+    for output in pydocstyle_errors:
+        print(output)
 
 
 if __name__ == "__main__":
     files = find_modified_python_files()
-    check_files(files)
+    mypy_errors, pydocstyle_errors = check_files(files)
+    announce_errors(mypy_errors, pydocstyle_errors)
+    if len(mypy_errors) > 0 or len(pydocstyle_errors) > 0:
+        print("Errors detected in mypy or pydocstyle")
+        exit(1)

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -53,11 +53,7 @@ def find_modified_python_files() -> list[str]:
         print("Environment variables GITHUB_BASE_REF or GITHUB_HEAD_REF are not set.")
         return []
 
-    command_to_run = f"""git diff --name-only 
-        origin/{base_ref} 
-        $(git merge-base origin/{base_ref} origin/{head_ref}) 
-        | grep '\.py$'
-    """
+    command_to_run = f"git diff --name-only origin/{base_ref} $(git merge-base origin/{base_ref} origin/{head_ref}) | grep '\.py$'"
 
     print(f"Running command: {command_to_run}")
     modified_files_raw = run_command(command_to_run)

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -12,7 +12,7 @@ import sys
 # This is done to solve otherwise quite annoying import issues.
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from util.miscellaneous_functions import get_project_root
+from util.miscellaneous_functions import get_project_root, print_header
 
 MYPY_COMMAND = 'mypy --ignore-missing-imports --disallow-untyped-defs '
 
@@ -108,13 +108,13 @@ def check_files(files_to_check: list[str]) -> tuple[list[str], list[str]]:
 
 def announce_errors(mypy_errors: list[str], pydocstyle_errors: list[str]):
     """Announce errors if present"""
-    print("\nMYPY RESULTS:\n")
+    print_header("MYPY RESULTS")
     for output in mypy_errors:
         # Because each file is individually run, the below string pattern occurs regularly.
         # The below re.sub action is designed to remove it.
         output = re.sub(r'\nFound \d+ errors* in 1 file \(checked 1 source file\)', '', output)
         print(output)
-    print("\nPYDOCSTYLE RESULTS:\n")
+    print_header("PYDOCSTYLE RESULTS")
     for output in pydocstyle_errors:
         print(output)
 

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -1,0 +1,82 @@
+import subprocess
+import os
+
+import pytest
+
+MYPY_COMMAND = 'mypy --ignore-missing-imports --disallow-untyped-defs '
+PYDOCSTYLE_COMMAND = 'pydocstyle '
+
+ERROR_KEYWORD = "error"
+
+def find_pydocstyle_config():
+
+
+
+def run_command(command: str) -> str:
+    """Utility function to run a shell command and capture the output."""
+    command_result = subprocess.run(command, text=True, shell=True, capture_output=True)
+    print_errors(command_result)
+    return command_result.stdout.strip()
+
+
+def print_errors(command_result: subprocess.CompletedProcess):
+    """Prints the error message if any."""
+    if command_result.stderr:
+        print("Error:", command_result.stderr)
+
+
+def find_modified_python_files() -> list[str]:
+    """Find modified Python files between the base and head branches."""
+    base_ref = os.getenv('GITHUB_BASE_REF')
+    head_ref = os.getenv('GITHUB_HEAD_REF')
+
+    command_to_run = f"""git diff --name-only 
+        origin/{base_ref} 
+        $(git merge-base origin/{base_ref} origin/{head_ref}) 
+        | grep '\.py$'
+    """
+    modified_files_raw = run_command(command_to_run)
+
+    modified_files = modified_files_raw.split()
+    return modified_files
+
+
+def get_file_string(modified_files: list[str]) -> str:
+    return '\'' + "\' \'".join(modified_files) + '\''
+
+
+def run_and_get_errored_outputs(files_to_check: list[str], command: str):
+    errored_outputs = []
+    for file_to_check in files_to_check:
+        output = run_command(command + ' ' + file_to_check)
+        if has_errors(output):
+            errored_outputs.append(output)
+    return errored_outputs
+
+def has_errors(output):
+    return ERROR_KEYWORD in output.lower()
+
+
+def check_files(files_to_check: list[str]):
+    if files_to_check:
+
+        mypy_outputs = run_and_get_errored_outputs(files_to_check, MYPY_COMMAND)
+        print("Mypy Results:\n")
+        for output in mypy_outputs:
+            output = output.replace('\nFound 1 error in 1 file (checked 1 source file)', '')
+            print(output)
+        pydocstyle_outputs = run_and_get_errored_outputs(files_to_check, PYDOCSTYLE_COMMAND)
+        print("Pydocstyle Results:\n")
+        for output in pydocstyle_outputs:
+            print(output)
+
+        # if has_errors(mypy_result) or has_errors(pydocstyle_result):
+        #     print("Errors detected in mypy or pydocstyle")
+        #     exit(1)
+    else:
+        print("No Python files were modified.")
+
+
+if __name__ == "__main__":
+    files = find_modified_python_files()
+    check_files(files)

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -36,9 +36,12 @@ PYDOCSTYLE_COMMAND = 'pydocstyle ' + find_pydocstyle_config()
 
 def run_command(command: str) -> str:
     """Executes a shell command and returns the standard output."""
-    result = subprocess.run(command, shell=True, text=True, capture_output=True, check=True)
-    return result.stdout
-
+    try:
+        result = subprocess.run(command, shell=True, text=True, capture_output=True, check=True)
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        # Called Process Error is expected in execution if type hinting or docstring errors exist
+        return e.stdout
 
 def find_modified_python_files() -> list[str]:
     """Find modified Python files between the base and head branches with enhanced debugging."""

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -6,6 +6,11 @@ running type and docstyle checking on the repository
 import re
 import subprocess
 import os
+import sys
+
+# The below code sets the working directory to be the root of the entire repository
+# This is done to solve otherwise quite annoying import issues.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from util.miscellaneous_functions import get_project_root
 

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -112,7 +112,7 @@ def announce_errors(mypy_errors: list[str], pydocstyle_errors: list[str]):
     for output in mypy_errors:
         # Because each file is individually run, the below string pattern occurs regularly.
         # The below re.sub action is designed to remove it.
-        output = re.sub(r'\nFound \d+ errors* in 1 file \(checked 1 source file\)', '', output)
+        output = re.sub(r'\nFound \d+ errors* in \d+ files* \(checked 1 source file\)', '', output)
         print(output)
     print_header("PYDOCSTYLE RESULTS")
     for output in pydocstyle_errors:

--- a/util/type_and_docstyle_checking.py
+++ b/util/type_and_docstyle_checking.py
@@ -36,15 +36,9 @@ PYDOCSTYLE_COMMAND = 'pydocstyle ' + find_pydocstyle_config()
 
 def run_command(command: str) -> str:
     """Executes a shell command and returns the standard output."""
-    try:
-        result = subprocess.run(command, shell=True, text=True, capture_output=True, check=True)
-        return result.stdout
-    except subprocess.CalledProcessError as e:
-        print(f"Command failed with error {e.returncode}")
-        print(f"Error output: {e.stderr}")
-        if e.stdout:  # Check if there is any standard output despite the error
-            print(f"Standard Output: {e.stdout}")
-        return ""
+    result = subprocess.run(command, shell=True, text=True, capture_output=True, check=True)
+    return result.stdout
+
 
 def find_modified_python_files() -> list[str]:
     """Find modified Python files between the base and head branches with enhanced debugging."""


### PR DESCRIPTION
#### Fixes

* Enhances #73 

#### Description

* The prior implementation include a lot of logic within the yaml file itself and was consequently difficult to debug and prone to unexpected errors.
* The new version migrates the majority of logic into python scripts, where the logic is rendered more comprehensible.
* Additionally, substantial logging has been added, to further improve debugging capabilities.

#### Testing

* Internal testing has been added via `test_type_and_docstyle_checking.py`

Prior testing was demonstrated in the following PRs:
* [This PR](https://github.com/maxachis/Github-Action-Test/pull/1#issuecomment-2043748474), which (after a few modifications) showcases how it would work on a PR
* [This other PR](https://github.com/maxachis/Github-Action-Test/pull/2), which shows it functioning again, but now _only on the new file I've created_. The other file, despite not being corrected, is not checked -- it only runs these checks on files that have been modified.


#### Performance

* As before, the Github action is light, and should run in 30 seconds or less
* Some overhead is added by transferring logic to Python, but this performance cost should be in the realm of milliseconds.
* In the case of performance dips, additional enhancements can be done to cache `mypy` and `pydocstyle` modules, although these are fairly light regardless