### PR TITLE
Common crawl deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ participant PDAP as PDAP API
 loop create batches of URLs <br/>for human labeling
   GH ->> GH: Crawl for a new batch<br/> of URLs with common_crawler<br/> or other methods
   GH ->> GH: Add metadata to each batch<br/> with source_tag_collector
-  GH ->> HF: Add the batch <br/> of URLs to a dataset
+  GH ->> HF: Add the batch <br/> of URLs to the <br/> training_urls dataset
   HF -->> GH: Confirm batch created
   GH ->> LS: Create labeling tasks <br/> from the batch
   LS -->> GH: Confirm tasks created

--- a/README.md
+++ b/README.md
@@ -54,10 +54,8 @@ participant PDAP as PDAP API
 loop create batches of URLs <br/>for human labeling
   GH ->> GH: Crawl for a new batch<br/> of URLs with common_crawler<br/> or other methods
   GH ->> GH: Add metadata to each batch<br/> with source_tag_collector
-  GH ->> HF: Add the batch <br/> of URLs to the <br/> training_urls dataset
-  HF -->> GH: Confirm batch created
-  GH ->> LS: Create labeling tasks <br/> from the batch
-  LS -->> GH: Confirm tasks created
+  GH ->> LS: Add the batch as <br/> labeling tasks in <br/> the Label Studio project
+  LS -->> GH: Confirm batch created
   GH ->> GH: add batches to a log file <br/> in this repo with URL<br/> and batch IDs
 end
 
@@ -68,7 +66,7 @@ end
 loop update training data <br/> with new annotations
   GH ->> LS: Check for completed <br/> annotation tasks
   LS -->> GH: Confirm new annotations <br/> since last check
-  GH ->> HF: Write new annotations to <br/> training dataset
+  GH ->> HF: Write new annotations to <br/> training-urls dataset
   GH ->> GH: log batch status to file
 end
 

--- a/common_crawler/README.md
+++ b/common_crawler/README.md
@@ -19,12 +19,10 @@ pip install -r requirements.txt
 
 Please ensure you have a `.env` file located in the root directory (not the `common_crawler` directory) 
 which contains the following environment variable:
+
 * HUGGINGFACE_ACCESS_TOKEN = The access token to enable writing to the associated PDAP dataset.
-To obtain your access token, consult user settings at https://huggingface.co/settings/tokens 
-and ensure you have write access to https://huggingface.co/PDAP .
-
-To check for duplicate urls against a Label Studio project, add the following environment variables:
-
+To obtain your access token, consult user settings at <https://huggingface.co/settings/tokens>
+and ensure you have write access to <https://huggingface.co/PDAP> .
 * LABEL_STUDIO_ACCESS_TOKEN = The access token for the Label Studio API. This can be
   obtained by logging into Label Studio and navigating to the [user account section](https://app.heartex.com/user/account), where the access token can be copied.
 * LABEL_STUDIO_PROJECT_ID = The project ID for the Label Studio API. This can be

--- a/common_crawler/README.md
+++ b/common_crawler/README.md
@@ -27,8 +27,6 @@ and ensure you have write access to <https://huggingface.co/PDAP> .
   obtained by logging into Label Studio and navigating to the [user account section](https://app.heartex.com/user/account), where the access token can be copied.
 * LABEL_STUDIO_PROJECT_ID = The project ID for the Label Studio API. This can be
   obtained by logging into Label Studio and navigating to the relevant project, where the project id will be in the URL.
-* LABEL_STUDIO_ORGANIZATION_ID = The organization ID for the Label Studio API. This can
-  be obtained by logging into Label Studio and navigating to the [Organization section](https://app.heartex.com/organization?page=1), where the organization ID can be copied.
 
 ### Instructions
 

--- a/common_crawler/README.md
+++ b/common_crawler/README.md
@@ -23,6 +23,15 @@ which contains the following environment variable:
 To obtain your access token, consult user settings at https://huggingface.co/settings/tokens 
 and ensure you have write access to https://huggingface.co/PDAP .
 
+To check for duplicate urls against a Label Studio project, add the following environment variables:
+
+* LABEL_STUDIO_ACCESS_TOKEN = The access token for the Label Studio API. This can be
+  obtained by logging into Label Studio and navigating to the [user account section](https://app.heartex.com/user/account), where the access token can be copied.
+* LABEL_STUDIO_PROJECT_ID = The project ID for the Label Studio API. This can be
+  obtained by logging into Label Studio and navigating to the relevant project, where the project id will be in the URL.
+* LABEL_STUDIO_ORGANIZATION_ID = The organization ID for the Label Studio API. This can
+  be obtained by logging into Label Studio and navigating to the [Organization section](https://app.heartex.com/organization?page=1), where the organization ID can be copied.
+
 ### Instructions
 
 Run the following script from the root directory

--- a/common_crawler/main.py
+++ b/common_crawler/main.py
@@ -133,7 +133,7 @@ def remove_local_duplicates(url_results: list[str]) -> list[str]:
 
     for index, url in enumerate(stripped_url_results):
         if url in unique_urls:
-            del (url_results[index - adjust])
+            del url_results[index - adjust]
             adjust += 1
         else:
             unique_urls.appendleft(url)
@@ -168,8 +168,7 @@ def remove_remote_duplicates(url_results: list[str]) -> list[str]:
 
     for index, url in enumerate(stripped_url_results):
         if url in remote_urls:
-            print(url_results[index - adjust])
-            del (url_results[index - adjust])
+            del url_results[index - adjust]
             adjust += 1
 
     return url_results

--- a/label_studio_interface/LabelStudioAPIManager.py
+++ b/label_studio_interface/LabelStudioAPIManager.py
@@ -3,12 +3,17 @@ import json
 import os
 import random
 import string
+import sys
 
 import requests
 from dotenv import load_dotenv
 from enum import Enum
 
-from LabelStudioConfig import LabelStudioConfig
+# The below code sets the working directory to be the root of the entire repository
+# This is done to solve otherwise quite annoying import issues.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from label_studio_interface.LabelStudioConfig import LabelStudioConfig
 
 """
 This script contains code which interfaces with the Label Studio API.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ accelerate>=0.27.2
 numpy>=1.26.4
 # html_tag_collector_only
 requests_html>=0.10.0
-lxml>=5.1.0, < 5.2.0
+lxml~=5.1.0
 pyppeteer>=2.0.0
 beautifulsoup4>=4.12.3


### PR DESCRIPTION
#### Fixes

* #83

#### Description

* URLs that are determined to be duplicates will be removed. This includes URLs being pulled in the same batch and those already in the Label Studio project
* Deduplication ignores http(s)://www.

#### Testing

1. Clone the repository and checkout the `common-crawl-83` branch
2. Setup a virtual environment and install the dependencies via `requirements.txt`
3. Create a `.env` file in the project's root directory. Populate it with the environment variable outlined in the README. The PDAP annotation project ID is 61550 and the organization ID is 9876
4. Run `main.py` as outlined in the README, for example: 
```bash
python common_crawler/main.py CC-MAIN-2023-50 '*.gov' police --config common_crawler/config.ini --pages 2
```