### PR TITLE
Annotation Pipeline

### DIFF
--- a/annotation_pipeline/populate_labelstudio.py
+++ b/annotation_pipeline/populate_labelstudio.py
@@ -12,42 +12,42 @@ from LabelStudioConfig import LabelStudioConfig
 from LabelStudioAPIManager import LabelStudioAPIManager
 
 def run_subprocess(terminal_command: str):
-	"""
-	Runs subprocesses (e.g. common crawl and html tag collector) and handles their outputs + errors
-	"""
+    """
+    Runs subprocesses (e.g. common crawl and html tag collector) and handles their outputs + errors
+    """
 
-	process = subprocess.Popen(terminal_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
+    process = subprocess.Popen(terminal_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
 
-	with process.stdout, process.stderr:
-		for line in process.stdout:
-			print(line, end='')
-		for line in process.stderr:
-			print(line, end='')
+    with process.stdout, process.stderr:
+        for line in process.stdout:
+            print(line, end='')
+        for line in process.stderr:
+            print(line, end='')
 
-	return_code = process.wait()
+    return_code = process.wait()
 
-	stdout, stderr = process.communicate()
+    stdout, stderr = process.communicate()
 
-	return return_code, stdout, stderr
+    return return_code, stdout, stderr
 
 def run_common_crawl(common_crawl_id: str, url: str, search_term: str, num_pages: str):
-	"""
-	Prompts terminal to run common crawl script provided the following:
-	common_crawl_id: (str)
-	url: (str)
-	search_term: (str)
-	num_pages: (str)
+    """
+    Prompts terminal to run common crawl script provided the following:
+    common_crawl_id: (str)
+    url: (str)
+    search_term: (str)
+    num_pages: (str)
 
-	See Common Crawl Documentation @ https://github.com/Police-Data-Accessibility-Project/data-source-identification/blob/main/common_crawler/README.md
+    See Common Crawl Documentation @ https://github.com/Police-Data-Accessibility-Project/data-source-identification/blob/main/common_crawler/README.md
 
-	CSV of crawled URL's uploaded to HuggingFace
-	"""
+    CSV of crawled URL's uploaded to HuggingFace
+    """
 
-	common_crawl = f"python ../common_crawler/main.py {common_crawl_id} '{url}' {search_term} --config ../common_crawler/config.ini --pages {num_pages}"
+    common_crawl = f"python ../common_crawler/main.py {common_crawl_id} '{url}' {search_term} --config ../common_crawler/config.ini --pages {num_pages}"
 
-	return_code, stdout, stderr = run_subprocess(common_crawl)
+    return_code, stdout, stderr = run_subprocess(common_crawl)
 
-	return return_code, stdout, stderr
+    return return_code, stdout, stderr
 
 def run_tag_collector(filename: str):
     """
@@ -63,87 +63,87 @@ def run_tag_collector(filename: str):
     return return_code, stdout, stderr
 
 def csv_to_label_studio_tasks(csv_file_path: str, batch_id: str, output_name: str) -> list[dict]:
-	"""
+    """
     Formats CSV into list[dict] with "data" key as labelstudio expects
     csv_file_path: path to csv with labeled source text
     batch_id: timestamp to append to all URL's in batch
     output_name: saves tag_collected CSV + batch_info in tag_collector/{output_name}
-	"""
-	df = pd.read_csv(csv_file_path)
-	df['batch_id'] = [batch_id] * len(df)
-	df = df.fillna('')
-	df.to_csv("tag_collector/" + output_name.replace("urls/", "", 1), index=False)
-	tasks = [{"data": row.to_dict()} for _, row in df.iterrows()]
-	return tasks
+    """
+    df = pd.read_csv(csv_file_path)
+    df['batch_id'] = [batch_id] * len(df)
+    df = df.fillna('')
+    df.to_csv("tag_collector/" + output_name.replace("urls/", "", 1), index=False)
+    tasks = [{"data": row.to_dict()} for _, row in df.iterrows()]
+    return tasks
 
 def main():
-	"""
-	This script automates the process of crawling for relevant URL's,
-	scraping HTML content from those pages, formatting the data as label studio tasks,
-	and uploading to label studio
-	"""
+    """
+    This script automates the process of crawling for relevant URL's,
+    scraping HTML content from those pages, formatting the data as label studio tasks,
+    and uploading to label studio
+    """
 
-	# ----------------- COMMON CRAWL -----------------------------------
+    # ----------------- COMMON CRAWL -----------------------------------
 
     #common crawl parameters
-	common_crawl_id = 'CC-MAIN-2024-10'
-	url = '*.gov'
-	search_term = 'police'
-	num_pages = '2'
+    common_crawl_id = 'CC-MAIN-2024-10'
+    url = '*.gov'
+    search_term = 'police'
+    num_pages = '2'
 
     #run common crawl
-	crawl_return_code, crawl_stdout, crawl_stderr = run_common_crawl(common_crawl_id, url, search_term, num_pages)
+    crawl_return_code, crawl_stdout, crawl_stderr = run_common_crawl(common_crawl_id, url, search_term, num_pages)
 
     #check success
-	if crawl_return_code != 0:
-		print(f"Common crawl script failed with error:\n{crawl_stderr}")
-		sys.exit(1)
+    if crawl_return_code != 0:
+        print(f"Common crawl script failed with error:\n{crawl_stderr}")
+        sys.exit(1)
 
     #print batch info to verify before continuing
-	batch_info = pd.read_csv("common_crawler/data/batch_info.csv").iloc[-1]
-	print("Batch Info:\n" + f"{batch_info}")
+    batch_info = pd.read_csv("common_crawler/data/batch_info.csv").iloc[-1]
+    print("Batch Info:\n" + f"{batch_info}")
 
-	input("Confirm batch info and csv on HuggingFace, press any key to proceed. Ctrl-c to quit")
+    input("Confirm batch info and csv on HuggingFace, press any key to proceed. Ctrl-c to quit")
 
-	#get urls from hugging face
-	REPO_ID = "PDAP/unlabeled-urls"
-	FILENAME = "urls/" + batch_info["Filename"] + ".csv"
-	df = pd.read_csv(hf_hub_download(repo_id=REPO_ID, filename=FILENAME, repo_type="dataset", local_dir="common_crawler/"), index_col=False)
+    #get urls from hugging face
+    REPO_ID = "PDAP/unlabeled-urls"
+    FILENAME = "urls/" + batch_info["Filename"] + ".csv"
+    df = pd.read_csv(hf_hub_download(repo_id=REPO_ID, filename=FILENAME, repo_type="dataset", local_dir="common_crawler/"), index_col=False)
 
-	# ----------------- TAG COLLECTOR ----------------------------------
+# ----------------- TAG COLLECTOR ----------------------------------
 
     #run tag collector
-	tag_collector_return_code, tag_collector_stdout, tag_collector_stderr = run_tag_collector(FILENAME)
+    tag_collector_return_code, tag_collector_stdout, tag_collector_stderr = run_tag_collector(FILENAME)
 
     #check success
-	if tag_collector_return_code != 0:
-		print(f"Tag collector script failed with error:\n{tag_collector_stderr}")
-		sys.exit(1)
+    if tag_collector_return_code != 0:
+        print(f"Tag collector script failed with error:\n{tag_collector_stderr}")
+        sys.exit(1)
 
-	#create batch_id from datetime (removes milliseconds)
-	datetime = batch_info["Datetime"]
-	batch_id = datetime[:datetime.find('.')]
+    #create batch_id from datetime (removes milliseconds)
+    datetime = batch_info["Datetime"]
+    batch_id = datetime[:datetime.find('.')]
 
-	# ----------------- LABEL STUDIO UPLOAD ----------------------------
+# ----------------- LABEL STUDIO UPLOAD ----------------------------
 
     #convert to label studio task format
-	data = csv_to_label_studio_tasks("labeled-source-text.csv", batch_id, FILENAME)
+    data = csv_to_label_studio_tasks("labeled-source-text.csv", batch_id, FILENAME)
 
-	# Load the configuration for the Label Studio API
-	config = LabelStudioConfig("dev.env")
-	if "REPLACE_WITH_YOUR_TOKEN" in config.authorization_token:
-		raise ValueError("Please replace the access token in dev.env with your own access token")
+    # Load the configuration for the Label Studio API
+    config = LabelStudioConfig("dev.env")
+    if "REPLACE_WITH_YOUR_TOKEN" in config.authorization_token:
+        raise ValueError("Please replace the access token in dev.env with your own access token")
 
-	# Create an API manager
-	api_manager = LabelStudioAPIManager(config)
+    # Create an API manager
+    api_manager = LabelStudioAPIManager(config)
 
     #import tasks
-	label_studio_response = api_manager.import_tasks_into_project(data)
+    label_studio_response = api_manager.import_tasks_into_project(data)
 
     #check import success
     if label_studio_response.status_code == 201:
-    	labelstudio_url = api_manager.api_url_constructor.get_import_url().rstrip('/import')
-    	print(f"Tasks successfully imported. Please access the project at {labelstudio_url} to perform review and annotation tasks")
+        labelstudio_url = api_manager.api_url_constructor.get_import_url().rstrip('/import')
+        print(f"Tasks successfully imported. Please access the project at {labelstudio_url} to perform review and annotation tasks")
     else:
         print(f"Failed to import tasks. Response code: {label_studio_response.status_code}\n{label_studio_response.text}")
         sys.exit(1)

--- a/annotation_pipeline/populate_labelstudio.py
+++ b/annotation_pipeline/populate_labelstudio.py
@@ -1,0 +1,156 @@
+from huggingface_hub import hf_hub_download
+import pandas as pd
+import subprocess
+import sys
+import os
+
+# Add the directory containing label studio interface tools to sys.path
+script_dir = os.path.abspath('../label_studio_interface/')
+sys.path.append(script_dir)
+
+from LabelStudioConfig import LabelStudioConfig
+from LabelStudioAPIManager import LabelStudioAPIManager
+
+def run_subprocess(terminal_command: str):
+	"""
+	Runs subprocesses (e.g. common crawl and html tag collector) and handles their outputs + errors
+	"""
+
+	process = subprocess.Popen(terminal_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
+
+	with process.stdout, process.stderr:
+		for line in process.stdout:
+			print(line, end='')
+		for line in process.stderr:
+			print(line, end='')
+
+	return_code = process.wait()
+
+	stdout, stderr = process.communicate()
+
+	return return_code, stdout, stderr
+
+def run_common_crawl(common_crawl_id: str, url: str, search_term: str, num_pages: str):
+	"""
+	Prompts terminal to run common crawl script provided the following:
+	common_crawl_id: (str)
+	url: (str)
+	search_term: (str)
+	num_pages: (str)
+
+	See Common Crawl Documentation @ https://github.com/Police-Data-Accessibility-Project/data-source-identification/blob/main/common_crawler/README.md
+
+	CSV of crawled URL's uploaded to HuggingFace
+	"""
+
+	common_crawl = f"python ../common_crawler/main.py {common_crawl_id} '{url}' {search_term} --config ../common_crawler/config.ini --pages {num_pages}"
+
+	return_code, stdout, stderr = run_subprocess(common_crawl)
+
+	return return_code, stdout, stderr
+
+def run_tag_collector(filename: str):
+    """
+    Prompts terminal to run tag collector on crawled URL's
+    filename: name of csv containing crawled URL's
+
+    CSV of URL's + collected tags saved in ./labeled-source-text.csv
+    """
+    tag_collector = f"python3 ../html_tag_collector/collector.py common_crawler/{filename} --render-javascript"
+
+    return_code, stdout, stderr = run_subprocess(tag_collector)
+
+    return return_code, stdout, stderr
+
+def csv_to_label_studio_tasks(csv_file_path: str, batch_id: str, output_name: str) -> list[dict]:
+	"""
+    Formats CSV into list[dict] with "data" key as labelstudio expects
+    csv_file_path: path to csv with labeled source text
+    batch_id: timestamp to append to all URL's in batch
+    output_name: saves tag_collected CSV + batch_info in tag_collector/{output_name}
+	"""
+	df = pd.read_csv(csv_file_path)
+	df['batch_id'] = [batch_id] * len(df)
+	df = df.fillna('')
+	df.to_csv("tag_collector/" + output_name.replace("urls/", "", 1), index=False)
+	tasks = [{"data": row.to_dict()} for _, row in df.iterrows()]
+	return tasks
+
+def main():
+	"""
+	This script automates the process of crawling for relevant URL's,
+	scraping HTML content from those pages, formatting the data as label studio tasks,
+	and uploading to label studio
+	"""
+
+	# ----------------- COMMON CRAWL -----------------------------------
+
+    #common crawl parameters
+	common_crawl_id = 'CC-MAIN-2024-10'
+	url = '*.gov'
+	search_term = 'police'
+	num_pages = '2'
+
+    #run common crawl
+	crawl_return_code, crawl_stdout, crawl_stderr = run_common_crawl(common_crawl_id, url, search_term, num_pages)
+
+    #check success
+	if crawl_return_code != 0:
+		print(f"Common crawl script failed with error:\n{crawl_stderr}")
+		sys.exit(1)
+
+    #print batch info to verify before continuing
+	batch_info = pd.read_csv("common_crawler/data/batch_info.csv").iloc[-1]
+	print("Batch Info:\n" + f"{batch_info}")
+
+	input("Confirm batch info and csv on HuggingFace, press any key to proceed. Ctrl-c to quit")
+
+	#get urls from hugging face
+	REPO_ID = "PDAP/unlabeled-urls"
+	FILENAME = "urls/" + batch_info["Filename"] + ".csv"
+	df = pd.read_csv(hf_hub_download(repo_id=REPO_ID, filename=FILENAME, repo_type="dataset", local_dir="common_crawler/"), index_col=False)
+
+	# ----------------- TAG COLLECTOR ----------------------------------
+
+    #run tag collector
+	tag_collector_return_code, tag_collector_stdout, tag_collector_stderr = run_tag_collector(FILENAME)
+
+    #check success
+	if tag_collector_return_code != 0:
+		print(f"Tag collector script failed with error:\n{tag_collector_stderr}")
+		sys.exit(1)
+
+	#create batch_id from datetime (removes milliseconds)
+	datetime = batch_info["Datetime"]
+	batch_id = datetime[:datetime.find('.')]
+
+	# ----------------- LABEL STUDIO UPLOAD ----------------------------
+
+    #convert to label studio task format
+	data = csv_to_label_studio_tasks("labeled-source-text.csv", batch_id, FILENAME)
+
+	# Load the configuration for the Label Studio API
+	config = LabelStudioConfig("dev.env")
+	if "REPLACE_WITH_YOUR_TOKEN" in config.authorization_token:
+		raise ValueError("Please replace the access token in dev.env with your own access token")
+
+	# Create an API manager
+	api_manager = LabelStudioAPIManager(config)
+
+    #import tasks
+	label_studio_response = api_manager.import_tasks_into_project(data)
+
+    #check import success
+    if label_studio_response.status_code == 201:
+    	labelstudio_url = api_manager.api_url_constructor.get_import_url().rstrip('/import')
+    	print(f"Tasks successfully imported. Please access the project at {labelstudio_url} to perform review and annotation tasks")
+    else:
+        print(f"Failed to import tasks. Response code: {label_studio_response.status_code}\n{label_studio_response.text}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    print("Running Annotation Pipeline...")
+    main()
+
+
+

--- a/annotation_pipeline/record_types.txt
+++ b/annotation_pipeline/record_types.txt
@@ -1,0 +1,36 @@
+Accident Reports
+Arrest Records
+Calls for Service
+Car GPS
+Citations
+Dispatch Logs
+Dispatch Recordings
+Field Contacts
+Incident Reports
+Misc Police Activity
+Officer Involved Shootings
+Stops
+Surveys
+Use of Force Reports
+Vehicle Pursuits
+Complaints & Misconduct
+Daily Activity Logs
+Training & Hiring Info
+Personnel Records
+Annual & Monthly Reports
+Budgets & Finances
+Contact Info & Agency Meta
+Geographic
+List of Data Sources
+Policies & Contracts
+Crime Maps & Reports
+Crime Statistics
+Media Bulletins
+Records Request Info
+Resources
+Sex Offender Registry
+Wanted Persons
+Booking Reports
+Court Cases
+Incarceration Records
+Poor Data Source

--- a/common_crawler/crawler.py
+++ b/common_crawler/crawler.py
@@ -63,7 +63,7 @@ class CommonCrawlerManager:
 
         return CommonCrawlResult(last_page, url_results)
 
-    def search_common_crawl_index(self, url: str, page: int = 0) -> list[dict]:
+    def search_common_crawl_index(self, url: str, page: int = 0, max_retries: int = 20) -> list[dict]:
         """
         This method is used to search the Common Crawl index for a given URL and page number
         Args:
@@ -79,21 +79,35 @@ class CommonCrawlerManager:
         search_url.add_parameter('output', 'json')
         search_url.add_parameter('page', page)
 
-        # Perform an HTTP GET request to retrieve records for the encoded URL.
-        response = requests.get(str(search_url))
+        retries = 0
+        delay = 1
 
-        # If the request is successful, parse each record from the response and return them.
-        if response.status_code == 200:
-            records = response.text.strip().split('\n')
-            print(f"Found {len(records)} records for {url} on page {page}")
-            return [json.loads(record) for record in records]
-        elif 'First Page is 0, Last Page is 0' in response.text:
-            print("No records exist in index matching the url search term")
-            return None
-        else:
-            print(f"Failed to get records for {url} on page {page}: {response.text}")
-            # Return None to indicate that no records were found or an error occurred.
-            return None
+        # put HTTP GET request in re-try loop in case of rate limiting. Once per second is nice enough per common crawl doc.
+        while retries < max_retries:
+            try:
+                # Perform an HTTP GET request to retrieve records for the encoded URL.
+                response = requests.get(str(search_url))
+                response.raise_for_status()
+
+                # If the request is successful, parse each record from the response and return them.
+                if response.status_code == 200:
+                    records = response.text.strip().split('\n')
+                    print(f"Found {len(records)} records for {url} on page {page}")
+                    return [json.loads(record) for record in records]
+                elif 'First Page is 0, Last Page is 0' in response.text:
+                    print("No records exist in index matching the url search term")
+                    return None
+            except requests.exceptions.RequestException as e:
+                if response.status_code == 500 and 'SlowDown' in response.text:
+                    retries += 1
+                    print(f"Rate limit exceeded. Rerun in {delay} second(s)... (Attempt {retries}/{max_retries})")
+                    time.sleep(delay)
+                else:
+                    print(f"Failed to get records for {url} on page {page}: {response_text}")
+                    return None
+
+        print(f"Max retries exceeded. Failed to get records for {url} on page {page}.")
+        return None
 
     @staticmethod
     def get_urls_with_keyword(records: list[dict], keyword) -> list[str]:

--- a/common_crawler/main.py
+++ b/common_crawler/main.py
@@ -280,7 +280,7 @@ def process_crawl_and_upload(
         return common_crawl_result
   
     handle_csv_and_upload(common_crawl_result, huggingface_api_manager, args)
->>>>>>> main
+
     return common_crawl_result
 
 

--- a/common_crawler/main.py
+++ b/common_crawler/main.py
@@ -6,7 +6,7 @@ import sys
 import os
 from datetime import datetime
 
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 
 # The below code sets the working directory to be the root of the entire repository
 # This is done to solve otherwise quite annoying import issues.
@@ -61,6 +61,7 @@ def main():
     )
 
     load_dotenv()
+    
     # Initialize the HuggingFace API Manager
     hf_access_token = os.getenv("HUGGINGFACE_ACCESS_TOKEN")
     if not hf_access_token:
@@ -270,16 +271,14 @@ def process_crawl_and_upload(
         print("No url results found. Ceasing main execution.")
         return common_crawl_result
 
-    handle_csv_and_upload(common_crawl_result, huggingface_api_manager, args, last_page)
-
     print("Removing urls already in the database")
     common_crawl_result.url_results = remove_local_duplicates(common_crawl_result.url_results)
     common_crawl_result.url_results = remove_remote_duplicates(common_crawl_result.url_results, label_studio_data)
     if not common_crawl_result.url_results:
         print("No urls not already present in the database found. Ceasing main execution.")
         return common_crawl_result
-  
-    handle_csv_and_upload(common_crawl_result, huggingface_api_manager, args)
+
+    handle_csv_and_upload(common_crawl_result, huggingface_api_manager, args, last_page)
 
     return common_crawl_result
 


### PR DESCRIPTION
## Addresses
#88

v1 of batch generation and pre-annotation script for label studio. This includes commits from the previous draft PR apologies, so I've indicated what's new vs. old.

## Description

`annotation_pipeline/populate_labelstudio.py`
- (new) takes in common crawl params as command line args, in same fashion as common_crawler/main.py
- (new) adds pre-annotations to json for labelstudio import (for record type only), record type passed as optional command line argument (--record-type)
- (old) script for initiating common crawl, html tag collection, and label studio import
- (old) generates a batch id, based on the timestamp of the associated common crawl (which will correspond to the timestamp in batch_info.csv)

`common_crawler/main.py`
- (old) modified to include csv filename of crawled urls in batch_info.csv (for retrieval in pipeline process)
- (old) batch info logic modified to ensure filename of unlabeled urls and Datetime in batch_info are the same
- (old) checks/handles for empty labelstudio project during deduplication

`common_crawler/crawler.py`
- (new) adds re-try logic in case of rate limiting from Common Crawler (retries max 20 times, once per second per common crawler). I've found that to be sufficient thus far

'record_types.txt'
- (new) list of valid record types that exist as choices in label studio scheme

## Testing
- will need an .env file in the root (data-source-identification) directory with HF, label studio credentials (as with running the common crawler script alone). You may also need a dev.env in the annotation_pipeline folder with labelstudio creds (`cp .env annotation_pipeline/dev.env`). I will concatenate those if need be.
- For label studio:
    - LABEL_STUDIO_PROJECT_ID=71148
    - LABEL_STUDIO_ORGANIZATION_ID=9876
The first run (with an empty common_crawler/cache.json) should not upload anything, due to this labelstudio project (ID=71148) already being populated with the urls generated by the crawl parameters below.
- usage `python populate_labelstudio.py CC-MAIN-2024-10 '*.gov' arrest --pages 8 --record-type "Arrest Records"`

## TODO
- search term (e.g. arrest) still only matched with URL, future versions should look in html for matching terms
- create workflow .yaml, github secrets for HF/labelstudio credentials
- documentation/requirements