### PR TITLE
Annotation Pipeline (manual workflow fixes)

### DIFF
--- a/.github/workflows/populate_labelstudio.yml
+++ b/.github/workflows/populate_labelstudio.yml
@@ -59,6 +59,8 @@ jobs:
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "action@github.com"
-        git add annotation_pipeline/data/*
+        git add annotation_pipeline/data/batch_info.csv
+        git add annotation_pipeline/data/cache.json
+        git add annotation_pipeline/data/tag_collector/*
         git commit -m "Update batch info and collected urls & tags"
         git push

--- a/.github/workflows/populate_labelstudio.yml
+++ b/.github/workflows/populate_labelstudio.yml
@@ -13,11 +13,11 @@ on:
         default: '*.gov'
       keyword:
         description: 'keyword'
-        required: 'true'
+        required: true
         default: 'police'
       pages:
         description: 'num pages'
-        required: 'true'
+        required: true
         default: '2'
       record_type:
         description: 'record type'

--- a/.github/workflows/populate_labelstudio.yml
+++ b/.github/workflows/populate_labelstudio.yml
@@ -59,7 +59,6 @@ jobs:
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "action@github.com"
-        git add annotation_pipeline/common_crawler/data/*
-        git add annotation_pipeline/tag_collector/*
+        git add annotation_pipeline/data/*
         git commit -m "Update batch info and collected urls & tags"
         git push

--- a/.github/workflows/populate_labelstudio.yml
+++ b/.github/workflows/populate_labelstudio.yml
@@ -21,7 +21,7 @@ on:
         default: '2'
       record_type:
         description: 'record type'
-        required: 'false'
+        required: false
         
 
 jobs:

--- a/annotation_pipeline/README.md
+++ b/annotation_pipeline/README.md
@@ -28,9 +28,11 @@ This Python script automates the process of crawling for relevant URLs, scraping
 
 ## Usage
 
-Run from within the annotation_pipeline/ folder
+Run from the parent directory (data-source-identification/)
 
-`python populate_labelstudio.py common_crawl_id url keyword --pages num_pages [--record-type record_type]`
+The output logs from common crawl will be stored in `annotation_pipeline/data` by default. This can be modified by editing the `annotation_pipeline/config.ini` file.
+
+`python annotation_pipeline/populate_labelstudio.py common_crawl_id url keyword --pages num_pages [--record-type record_type]`
 
 - `common_crawl_id`: ID of the Common Crawl Corpus to search
 - `url`: Type of URL to search for (e.g. *.gov for all .gov domains).
@@ -38,4 +40,4 @@ Run from within the annotation_pipeline/ folder
 - `--pages num_pages`: Number of pages to search
 - `--record-type record_type` (optional): Assumed record type for pre-annotation.
 
-e.g. `python populate_labelstudio.py CC-MAIN-2024-10 '*.gov' arrest --pages 2 --record-type 'Arrest Records'`
+e.g. `python annotation_pipeline/populate_labelstudio.py CC-MAIN-2024-10 '*.gov' arrest --pages 2 --record-type 'Arrest Records'`

--- a/annotation_pipeline/config.ini
+++ b/annotation_pipeline/config.ini
@@ -10,7 +10,7 @@ cache_filename = cache
 # Directory where data files (both cache and output) are stored.
 # Change as needed for different environments.
 # Path is relative from working directory that executes common_crawler/main.py
-data_dir = annotation_pipeline/common_crawler/data
+data_dir = annotation_pipeline/data
 
 # Filename for the output CSV containing crawled URLs.
 output_filename = urls

--- a/annotation_pipeline/config.ini
+++ b/annotation_pipeline/config.ini
@@ -1,0 +1,19 @@
+# This configuration file contains default settings for the Common Crawler application.
+# Settings can be modified to suit different environments or testing needs.
+
+[DEFAULT]
+# Filename for the cache. Stores which pages have been crawled
+# at which combinations of index, url search term, and keyword
+# to avoid re-crawling them.
+cache_filename = cache
+
+# Directory where data files (both cache and output) are stored.
+# Change as needed for different environments.
+# Path is relative from working directory that executes common_crawler/main.py
+data_dir = annotation_pipeline/common_crawler/data
+
+# Filename for the output CSV containing crawled URLs.
+output_filename = urls
+
+# Name of the huggingface repo
+huggingface_repo_id = PDAP/unlabeled-urls

--- a/annotation_pipeline/populate_labelstudio.py
+++ b/annotation_pipeline/populate_labelstudio.py
@@ -78,6 +78,7 @@ def csv_to_label_studio_tasks(csv_file_path: str, batch_id: str, output_name: st
     df = pd.read_csv(csv_file_path)
     df['batch_id'] = [batch_id] * len(df)
     df = df.fillna('')
+    os.makedirs("annotation_pipeline/tag_collector/", exist_ok=True)
     df.to_csv("annotation_pipeline/tag_collector/" + output_name.replace("urls/", "", 1), index=False)
 
     tasks = []

--- a/annotation_pipeline/populate_labelstudio.py
+++ b/annotation_pipeline/populate_labelstudio.py
@@ -62,7 +62,7 @@ def run_tag_collector(filename: str):
 
     CSV of URL's + collected tags saved in ./labeled-source-text.csv
     """
-    tag_collector = f"python3 html_tag_collector/collector.py annotation_pipeline/common_crawler/{filename} --render-javascript"
+    tag_collector = f"python3 html_tag_collector/collector.py annotation_pipeline/data/{filename} --render-javascript"
 
     return_code, stdout, stderr = run_subprocess(tag_collector)
 
@@ -148,7 +148,7 @@ def process_crawl(common_crawl_id: str, url: str, search_term: str, num_pages: s
         raise ValueError(f"Common crawl script failed:\n{crawl_stderr}")
 
     #print batch info to verify before continuing
-    batch_info = pd.read_csv("annotation_pipeline/common_crawler/data/batch_info.csv").iloc[-1]
+    batch_info = pd.read_csv("annotation_pipeline/data/batch_info.csv").iloc[-1]
     print("Batch Info:\n" + f"{batch_info}")
 
     if(batch_info["Count"] == 0):
@@ -234,7 +234,7 @@ def main():
         #get urls from hugging face
         REPO_ID = get_huggingface_repo_id("annotation_pipeline/config.ini")
         FILENAME = "urls/" + batch_info["Filename"] + ".csv"
-        hf_hub_download(repo_id=REPO_ID, filename=FILENAME, repo_type="dataset", local_dir="annotation_pipeline/common_crawler/")
+        hf_hub_download(repo_id=REPO_ID, filename=FILENAME, repo_type="dataset", local_dir="annotation_pipeline/data/")
 
         # TAG COLLECTOR
         batch_id = process_tag_collector(batch_info, FILENAME)

--- a/annotation_pipeline/populate_labelstudio.py
+++ b/annotation_pipeline/populate_labelstudio.py
@@ -73,13 +73,13 @@ def csv_to_label_studio_tasks(csv_file_path: str, batch_id: str, output_name: st
     Formats CSV into list[dict] with "data" key as labelstudio expects
     csv_file_path: path to csv with labeled source text
     batch_id: timestamp to append to all URL's in batch
-    output_name: saves tag_collected CSV + batch_info in tag_collector/{output_name}
+    output_name: saves tag_collected CSV + batch_info in data/tag_collector/{output_name}
     """
     df = pd.read_csv(csv_file_path)
     df['batch_id'] = [batch_id] * len(df)
     df = df.fillna('')
-    os.makedirs("annotation_pipeline/tag_collector/", exist_ok=True)
-    df.to_csv("annotation_pipeline/tag_collector/" + output_name.replace("urls/", "", 1), index=False)
+    os.makedirs("annotation_pipeline/data/tag_collector/", exist_ok=True)
+    df.to_csv("annotation_pipeline/data/tag_collector/" + output_name.replace("urls/", "", 1), index=False)
 
     tasks = []
 

--- a/annotation_pipeline/populate_labelstudio.py
+++ b/annotation_pipeline/populate_labelstudio.py
@@ -49,7 +49,7 @@ def run_common_crawl(common_crawl_id: str, url: str, search_term: str, num_pages
     CSV of crawled URL's uploaded to HuggingFace
     """
 
-    common_crawl = f"python ../common_crawler/main.py {common_crawl_id} '{url}' {search_term} --config ../common_crawler/config.ini --pages {num_pages}"
+    common_crawl = f"python common_crawler/main.py {common_crawl_id} '{url}' {search_term} --config annotation_pipeline/config.ini --pages {num_pages}"
 
     return_code, stdout, stderr = run_subprocess(common_crawl)
 
@@ -62,7 +62,7 @@ def run_tag_collector(filename: str):
 
     CSV of URL's + collected tags saved in ./labeled-source-text.csv
     """
-    tag_collector = f"python3 ../html_tag_collector/collector.py common_crawler/{filename} --render-javascript"
+    tag_collector = f"python3 html_tag_collector/collector.py annotation_pipeline/common_crawler/{filename} --render-javascript"
 
     return_code, stdout, stderr = run_subprocess(tag_collector)
 
@@ -78,7 +78,7 @@ def csv_to_label_studio_tasks(csv_file_path: str, batch_id: str, output_name: st
     df = pd.read_csv(csv_file_path)
     df['batch_id'] = [batch_id] * len(df)
     df = df.fillna('')
-    df.to_csv("tag_collector/" + output_name.replace("urls/", "", 1), index=False)
+    df.to_csv("annotation_pipeline/tag_collector/" + output_name.replace("urls/", "", 1), index=False)
 
     tasks = []
 
@@ -147,7 +147,7 @@ def process_crawl(common_crawl_id: str, url: str, search_term: str, num_pages: s
         raise ValueError(f"Common crawl script failed:\n{crawl_stderr}")
 
     #print batch info to verify before continuing
-    batch_info = pd.read_csv("common_crawler/data/batch_info.csv").iloc[-1]
+    batch_info = pd.read_csv("annotation_pipeline/common_crawler/data/batch_info.csv").iloc[-1]
     print("Batch Info:\n" + f"{batch_info}")
 
     if(batch_info["Count"] == 0):
@@ -189,9 +189,9 @@ def label_studio_upload(batch_id: str, FILENAME: str, record_type: str):
     data = csv_to_label_studio_tasks("labeled-source-text.csv", batch_id, FILENAME, record_type)
 
     # Load the configuration for the Label Studio API
-    config = LabelStudioConfig("../.env")
+    config = LabelStudioConfig(".env")
     if "REPLACE_WITH_YOUR_TOKEN" in config.authorization_token:
-        raise ValueError("Please replace the access token in dev.env with your own access token")
+        raise ValueError("Please replace the access token in .env with your own access token")
 
     # Create an API manager
     api_manager = LabelStudioAPIManager(config)
@@ -221,18 +221,19 @@ def main():
     parser.add_argument('--record-type', type=str, required=False, help='assumed record type for pre-annotation')
     args = parser.parse_args()
 
-    valid_record_types = get_valid_record_types("record_types.txt")
-    if args.record_type is not None and args.record_type not in valid_record_types:
-        raise ValueError(f"Invalid record type: {args.record_type}. Must be one of {valid_record_types}")
-        return
+    if args.record_type is not None:
+        valid_record_types = get_valid_record_types("annotation_pipeline/record_types.txt")
+        if args.record_type not in valid_record_types:
+            raise ValueError(f"Invalid record type: {args.record_type}. Must be one of {valid_record_types}")
+            return
 
     try:
         # COMMON CRAWL
         batch_info = process_crawl(args.common_crawl_id, args.url, args.keyword, args.pages)
         #get urls from hugging face
-        REPO_ID = get_huggingface_repo_id("../common_crawler/config.ini")
+        REPO_ID = get_huggingface_repo_id("annotation_pipeline/config.ini")
         FILENAME = "urls/" + batch_info["Filename"] + ".csv"
-        hf_hub_download(repo_id=REPO_ID, filename=FILENAME, repo_type="dataset", local_dir="common_crawler/")
+        hf_hub_download(repo_id=REPO_ID, filename=FILENAME, repo_type="dataset", local_dir="annotation_pipeline/common_crawler/")
 
         # TAG COLLECTOR
         batch_id = process_tag_collector(batch_info, FILENAME)

--- a/annotation_pipeline/populate_labelstudio.py
+++ b/annotation_pipeline/populate_labelstudio.py
@@ -80,6 +80,10 @@ def csv_to_label_studio_tasks(csv_file_path: str, batch_id: str, output_name: st
     df = df.fillna('')
     os.makedirs("annotation_pipeline/data/tag_collector/", exist_ok=True)
     df.to_csv("annotation_pipeline/data/tag_collector/" + output_name.replace("urls/", "", 1), index=False)
+    
+    #remove labeled-source-text.csv (updated and written to data/tag_collector)
+    if os.path.exists(csv_file_path):
+        os.remove(csv_file_path)
 
     tasks = []
 

--- a/annotation_pipeline/requirements.txt
+++ b/annotation_pipeline/requirements.txt
@@ -1,4 +1,4 @@
-pandas~=2.1.4
+pandas==2.1.4
 python-dotenv~=1.0.1
 argparse~=1.1
 huggingface-hub~=0.22.2


### PR DESCRIPTION
## Addresses
#96

This PR has tried and true fixes in the manual workflow merged last time. Primarily cleans up path issues that arose from running populate_labelstudio.py in a different location. This also simplifies the output folders for batch_info, cache, and tag collected csv's.

## Description

`annotation_pipeline/populate_labelstudio.py`
- path clean up. regardless of manual workflow or running locally, populate_labelstudio.py is now designed to be run from the parent directory (data-source-identification/)

`annotation_pipeline/config.ini`
- new config file for populate_labelstudio to specify save location in annotation_pipeline/data

`annotation_pipeline/README.md`
- updated instructions for running populate_labelstudio locally

`.github/workflows/populate_labelstudio.yml`
- fixes to yaml (string to bool (oops))
- pushes output logs to annotation_pipeline/data