### PR TITLE
CKAN URL Identifier

### DIFF
--- a/html_tag_collector/RootURLCache.py
+++ b/html_tag_collector/RootURLCache.py
@@ -6,7 +6,7 @@ import json
 import os
 import ssl
 
-from common import get_user_agent
+from html_tag_collector.common import get_user_agent
 
 DEBUG = False
 

--- a/html_tag_collector/collector.py
+++ b/html_tag_collector/collector.py
@@ -24,6 +24,7 @@ import multiprocessing
 import requests
 from requests_html import AsyncHTMLSession
 import asyncio
+from from_root import from_root
 import pyppeteer
 from tqdm import tqdm
 from tqdm.asyncio import tqdm
@@ -32,9 +33,12 @@ from bs4 import BeautifulSoup
 import polars as pl
 from urllib.parse import urlparse
 
-from RootURLCache import RootURLCache
-from common import get_user_agent
-from DataClassTags import Tags
+p = from_root(".gitignore").parent
+sys.path.insert(1, str(p))
+
+from html_tag_collector.RootURLCache import RootURLCache
+from html_tag_collector.common import get_user_agent
+from html_tag_collector.DataClassTags import Tags
 
 
 # Define the list of header tags we want to extract

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,8 +19,10 @@ datasets>=2.17.1
 accelerate>=0.27.2
 numpy>=1.26.4
 multimodal-transformers>=0.3.1
-# html_tag_collector_only
+# html_tag_collector only
 requests_html>=0.10.0
 lxml~=5.1.0
+lxml_html_clean~=0.4.1
 pyppeteer>=2.0.0
 beautifulsoup4>=4.12.3
+from_root

--- a/source_collectors/ckan/ckan_identifier.py
+++ b/source_collectors/ckan/ckan_identifier.py
@@ -1,0 +1,27 @@
+"""This program identifies if a given URL is a CKAN-hosted website"""
+import re
+
+from bs4 import BeautifulSoup
+from from_root import from_root
+import requests
+
+
+def is_ckan_hosted(url):
+    head = requests.get(url)
+    soup = BeautifulSoup(head.content, "lxml")
+    
+    ckan_tag = soup.head.find(content=re.compile("ckan \d+\.\d+\.\d+"))
+    if ckan_tag is not None:
+        return True
+    
+    return False
+
+
+def main():
+    url = "https://www.w3schools.com/python/python_regex.asp"
+    print(is_ckan_hosted(url))
+
+
+if __name__ == "__main__":
+    main()
+    

--- a/source_collectors/ckan/ckan_identifier.py
+++ b/source_collectors/ckan/ckan_identifier.py
@@ -35,7 +35,13 @@ def is_ckan_hosted(response: Response) -> bool:
     :param response: The response object.
     :return: True if the CKAN version tag is found, False otherwise.
     """
+    if not response.ok:
+        return False
+
     soup = BeautifulSoup(response.content, "lxml")
+
+    if soup.head is None:
+        return False
 
     # Checks if the CKAN version tag is present, looks like this:
     # <meta name="generator" content="ckan 2.10.5">

--- a/source_collectors/ckan/ckan_identifier.py
+++ b/source_collectors/ckan/ckan_identifier.py
@@ -1,27 +1,73 @@
 """This program identifies if a given URL is a CKAN-hosted website"""
-import re
 
+import re
+import sys
+
+import asyncio
 from bs4 import BeautifulSoup
 from from_root import from_root
+import polars as pl
 import requests
+from requests import Response
+
+p = from_root(".gitignore").parent
+sys.path.insert(1, str(p))
+
+from html_tag_collector.collector import run_get_response
 
 
-def is_ckan_hosted(url):
-    head = requests.get(url)
-    soup = BeautifulSoup(head.content, "lxml")
-    
+def get_responses(urls: list[str]) -> list[Response]:
+    """Uses the tag collector's run_get_response method to get response objects for each url.
+
+    :param urls: The list of urls.
+    :return: The list of resulting responses.
+    """
+    loop = asyncio.get_event_loop()
+    future = asyncio.ensure_future(run_get_response(urls))
+    loop.run_until_complete(future)
+    return future.result()
+
+
+def is_ckan_hosted(response: Response) -> bool:
+    """Checks if the response content contains the CKAN version tag.
+
+    :param response: The response object.
+    :return: True if the CKAN version tag is found, False otherwise.
+    """
+    soup = BeautifulSoup(response.content, "lxml")
+
+    # Checks if the CKAN version tag is present, looks like this:
+    # <meta name="generator" content="ckan 2.10.5">
     ckan_tag = soup.head.find(content=re.compile("ckan \d+\.\d+\.\d+"))
     if ckan_tag is not None:
         return True
-    
+
     return False
 
 
 def main():
-    url = "https://www.w3schools.com/python/python_regex.asp"
-    print(is_ckan_hosted(url))
+    file = sys.argv[1]
+    df = pl.read_csv(file)
+
+    results = get_responses(urls=list(df["url"]))
+
+    results_df = pl.from_dicts(results)
+    urls_and_responses = pl.DataFrame(
+        [
+            pl.Series("url", df["url"]),
+            pl.Series("response", results_df["response"]),
+        ]
+    )
+
+    # Add a new column indicating if the URL contains the CKAN version tag
+    urls_and_responses = urls_and_responses.with_columns(
+        pl.col("response")
+        .map_elements(is_ckan_hosted, return_dtype=bool)
+        .alias("is_ckan_hosted")
+    )
+
+    urls_and_responses.select(["url", "is_ckan_hosted"]).write_csv("output.csv")
 
 
 if __name__ == "__main__":
     main()
-    


### PR DESCRIPTION
Description

* Mostly waiting on https://github.com/Police-Data-Accessibility-Project/data-source-identification/pull/106 so that the README can be updated with the identifier in mind
* Adds a CKAN URL identifier that determines whether or not each URL is hosted by CKAN

Testing

1. Checkout the branch
2. In the `source_collectors/ckan` folder, create a CSV file with a column labeled "url" and populate it with urls. Below is an example CSV file that may be used for testing
3. In the root project directory, create a virtual env and activate it
    ```cmd
    python -m venv venv
    source venv/bin/activate
    ```
4. Install the requirements
    ```cmd
    pip install -r requirements.txt
    ```
5. (Optional) Move to the ckan folder
    ```cmd
    cd source_collectors/ckan
    ```
6. Run the program with the CSV file as the second argument
    ```cmd
    python ckan_identifier.py urls.csv
    ```
7. Output will be located in `output.csv`

Sample CSV:
```csv
url
https://catalog.data.gov/dataset/operation-aquila
https://github.com/Police-Data-Accessibility-Project/data-source-identification/compare/ckan-identifier?expand=1
https://docs.ckan.org/en/2.9/api/
https://data.gov/open-gov/
https://data.boston.gov/dataset/police-districts
https://open.jacksonms.gov/dataset/police-precinct-city-of-jackson-and-wards
https://duckduckgo.com/
https://docs.pola.rs/
```