### PR TITLE
feat(database): add agency not in database in annotate agencies

### DIFF
--- a/collector_db/AsyncDatabaseClient.py
+++ b/collector_db/AsyncDatabaseClient.py
@@ -976,6 +976,18 @@ class AsyncDatabaseClient:
     ):
         if is_new and agency_id is not None:
             raise ValueError("agency_id must be None when is_new is True")
+
+        # Check if agency exists in database -- if not, add with placeholder
+        if agency_id is not None:
+            statement = select(Agency).where(Agency.agency_id == agency_id)
+            result = await session.execute(statement)
+            if len(result.all()) == 0:
+                agency = Agency(
+                    agency_id=agency_id,
+                    name=PLACEHOLDER_AGENCY_NAME
+                )
+                await session.merge(agency)
+
         url_agency_suggestion = UserUrlAgencySuggestion(
             url_id=url_id,
             agency_id=agency_id,

--- a/tests/helpers/complex_test_data_functions.py
+++ b/tests/helpers/complex_test_data_functions.py
@@ -3,7 +3,8 @@ from pydantic import BaseModel
 from collector_db.DTOs.InsertURLsInfo import InsertURLsInfo
 from collector_db.DTOs.URLMapping import URLMapping
 from collector_manager.enums import URLStatus
-from core.enums import RecordType
+from core.enums import RecordType, SuggestionType
+from helpers.DBDataCreator import BatchURLCreationInfo
 from tests.helpers.DBDataCreator import DBDataCreator
 
 class AnnotationSetupInfo(BaseModel):
@@ -28,6 +29,26 @@ async def setup_for_get_next_url_for_annotation(
     )
     return AnnotationSetupInfo(batch_id=batch_id, insert_urls_info=insert_urls_info)
 
+class AnnotateAgencySetupInfo(BaseModel):
+    batch_id: int
+    url_ids: list[int]
+
+async def setup_for_annotate_agency(
+        db_data_creator: DBDataCreator,
+        url_count: int,
+        suggestion_type: SuggestionType = SuggestionType.UNKNOWN
+):
+    buci: BatchURLCreationInfo = await db_data_creator.batch_and_urls(
+        url_count=url_count,
+        with_html_content=True
+    )
+    await db_data_creator.auto_suggestions(
+        url_ids=buci.url_ids,
+        num_suggestions=1,
+        suggestion_type=suggestion_type
+    )
+
+    return AnnotateAgencySetupInfo(batch_id=buci.batch_id, url_ids=buci.url_ids)
 
 class FinalReviewSetupInfo(BaseModel):
     batch_id: int

--- a/tests/helpers/complex_test_data_functions.py
+++ b/tests/helpers/complex_test_data_functions.py
@@ -4,7 +4,7 @@ from collector_db.DTOs.InsertURLsInfo import InsertURLsInfo
 from collector_db.DTOs.URLMapping import URLMapping
 from collector_manager.enums import URLStatus
 from core.enums import RecordType, SuggestionType
-from helpers.DBDataCreator import BatchURLCreationInfo
+from tests.helpers.DBDataCreator import BatchURLCreationInfo
 from tests.helpers.DBDataCreator import DBDataCreator
 
 class AnnotationSetupInfo(BaseModel):

--- a/tests/test_automated/integration/api/test_annotate.py
+++ b/tests/test_automated/integration/api/test_annotate.py
@@ -13,6 +13,7 @@ from core.DTOs.GetNextURLForAnnotationResponse import GetNextURLForAnnotationRes
 from core.DTOs.RecordTypeAnnotationPostInfo import RecordTypeAnnotationPostInfo
 from core.DTOs.RelevanceAnnotationPostInfo import RelevanceAnnotationPostInfo
 from core.enums import RecordType, SuggestionType
+from helpers.complex_test_data_functions import AnnotateAgencySetupInfo, setup_for_annotate_agency
 from html_tag_collector.DataClassTags import ResponseHTMLInfo
 from tests.helpers.DBDataCreator import BatchURLCreationInfo
 from tests.test_automated.integration.api.conftest import MOCK_USER_ID
@@ -221,7 +222,6 @@ async def test_annotate_agency_multiple_auto_suggestions(api_test_helper):
     The user should receive all of the auto suggestions with full detail
     """
     ath = api_test_helper
-    adb_client = ath.adb_client()
     buci: BatchURLCreationInfo = await ath.db_data_creator.batch_and_urls(
         url_count=1,
         with_html_content=True
@@ -264,7 +264,6 @@ async def test_annotate_agency_single_unknown_auto_suggestion(api_test_helper):
     The user should receive a single Unknown Auto Suggestion lacking other detail
     """
     ath = api_test_helper
-    adb_client = ath.adb_client()
     buci: BatchURLCreationInfo = await ath.db_data_creator.batch_and_urls(
         url_count=1,
         with_html_content=True
@@ -306,7 +305,6 @@ async def test_annotate_agency_single_confirmed_agency(api_test_helper):
     The user should not receive this URL to annotate
     """
     ath = api_test_helper
-    adb_client = ath.adb_client()
     buci: BatchURLCreationInfo = await ath.db_data_creator.batch_and_urls(
         url_count=1,
         with_html_content=True
@@ -325,20 +323,16 @@ async def test_annotate_agency_other_user_annotation(api_test_helper):
     Our user should still receive this URL to annotate
     """
     ath = api_test_helper
-    adb_client = ath.adb_client()
-    buci: BatchURLCreationInfo = await ath.db_data_creator.batch_and_urls(
-        url_count=1,
-        with_html_content=True
+    setup_info: AnnotateAgencySetupInfo = await setup_for_annotate_agency(
+        db_data_creator=ath.db_data_creator,
+        url_count=1
     )
-    await ath.db_data_creator.auto_suggestions(
-        url_ids=buci.url_ids,
-        num_suggestions=1,
-        suggestion_type=SuggestionType.UNKNOWN
-    )
+    url_ids = setup_info.url_ids
+
 
     await ath.db_data_creator.manual_suggestion(
         user_id=MOCK_USER_ID + 1,
-        url_id=buci.url_ids[0],
+        url_id=url_ids[0],
     )
 
     response = await ath.request_validator.get_next_agency_annotation()
@@ -346,7 +340,7 @@ async def test_annotate_agency_other_user_annotation(api_test_helper):
     assert response.next_annotation
     next_annotation = response.next_annotation
     # Check that url_id matches the one we inserted
-    assert next_annotation.url_id == buci.url_ids[0]
+    assert next_annotation.url_id == url_ids[0]
 
     # Check that html data is present
     assert next_annotation.html_info.description != ""
@@ -364,20 +358,15 @@ async def test_annotate_agency_submit_and_get_next(api_test_helper):
     Until another relevant URL is added
     """
     ath = api_test_helper
-    adb_client = ath.adb_client()
-    buci: BatchURLCreationInfo = await ath.db_data_creator.batch_and_urls(
-        url_count=2,
-        with_html_content=True
+    setup_info: AnnotateAgencySetupInfo = await setup_for_annotate_agency(
+        db_data_creator=ath.db_data_creator,
+        url_count=2
     )
-    await ath.db_data_creator.auto_suggestions(
-        url_ids=buci.url_ids,
-        num_suggestions=1,
-        suggestion_type=SuggestionType.UNKNOWN
-    )
+    url_ids = setup_info.url_ids
 
     # User should submit an annotation and receive the next
     response = await ath.request_validator.post_agency_annotation_and_get_next(
-        url_id=buci.url_ids[0],
+        url_id=url_ids[0],
         agency_annotation_post_info=URLAgencyAnnotationPostInfo(
             suggested_agency=await ath.db_data_creator.agency(),
             is_new=False
@@ -388,7 +377,7 @@ async def test_annotate_agency_submit_and_get_next(api_test_helper):
 
     # User should submit this annotation and receive none for the next
     response = await ath.request_validator.post_agency_annotation_and_get_next(
-        url_id=buci.url_ids[1],
+        url_id=url_ids[1],
         agency_annotation_post_info=URLAgencyAnnotationPostInfo(
             suggested_agency=await ath.db_data_creator.agency(),
             is_new=False
@@ -407,19 +396,15 @@ async def test_annotate_agency_submit_new(api_test_helper):
     """
     ath = api_test_helper
     adb_client = ath.adb_client()
-    buci: BatchURLCreationInfo = await ath.db_data_creator.batch_and_urls(
-        url_count=1,
-        with_html_content=True
+    setup_info: AnnotateAgencySetupInfo = await setup_for_annotate_agency(
+        db_data_creator=ath.db_data_creator,
+        url_count=1
     )
-    await ath.db_data_creator.auto_suggestions(
-        url_ids=buci.url_ids,
-        num_suggestions=1,
-        suggestion_type=SuggestionType.UNKNOWN
-    )
+    url_ids = setup_info.url_ids
 
     # User should submit an annotation and mark it as New
     response = await ath.request_validator.post_agency_annotation_and_get_next(
-        url_id=buci.url_ids[0],
+        url_id=url_ids[0],
         agency_annotation_post_info=URLAgencyAnnotationPostInfo(
             suggested_agency=await ath.db_data_creator.agency(),
             is_new=True

--- a/tests/test_automated/integration/api/test_annotate.py
+++ b/tests/test_automated/integration/api/test_annotate.py
@@ -13,7 +13,7 @@ from core.DTOs.GetNextURLForAnnotationResponse import GetNextURLForAnnotationRes
 from core.DTOs.RecordTypeAnnotationPostInfo import RecordTypeAnnotationPostInfo
 from core.DTOs.RelevanceAnnotationPostInfo import RelevanceAnnotationPostInfo
 from core.enums import RecordType, SuggestionType
-from helpers.complex_test_data_functions import AnnotateAgencySetupInfo, setup_for_annotate_agency
+from tests.helpers.complex_test_data_functions import AnnotateAgencySetupInfo, setup_for_annotate_agency
 from html_tag_collector.DataClassTags import ResponseHTMLInfo
 from tests.helpers.DBDataCreator import BatchURLCreationInfo
 from tests.test_automated.integration.api.conftest import MOCK_USER_ID


### PR DESCRIPTION
Previously, the `/annotate/agencies` `POST` method would return a 500 error when an agency whose ID was not yet in the DBI database was submitted. This has been resolved.

https://github.com/Police-Data-Accessibility-Project/data-source-identification/issues/190