### PR TITLE
feat(app): enable task loop to repeat if prerequisites met

### DIFF
--- a/ENV.md
+++ b/ENV.md
@@ -21,4 +21,5 @@ Please ensure these are properly defined in a `.env` file in the root directory.
 |`PDAP_EMAIL`| An email address for accessing the PDAP API.                                                                                                                                                                                                                      | `abc123@test.com`               |
 |`PDAP_PASSWORD`| A password for accessing the PDAP API.                                                                                                                                                                                                                            | `abc123`               |
 |`PDAP_API_KEY`| An API key for accessing the PDAP API.                                                                                                                                                                                                                            | `abc123`               |
+|`DISCORD_WEBHOOK_URL`| The URL for the Discord webhook used for notifications| `abc123`               |
 

--- a/api/main.py
+++ b/api/main.py
@@ -20,6 +20,7 @@ from html_tag_collector.ResponseParser import HTMLResponseParser
 from html_tag_collector.RootURLCache import RootURLCache
 from html_tag_collector.URLRequestInterface import URLRequestInterface
 from hugging_face.HuggingFaceInterface import HuggingFaceInterface
+from util.DiscordNotifier import DiscordPoster
 from util.helper_functions import get_from_env
 
 
@@ -40,6 +41,9 @@ async def lifespan(app: FastAPI):
         url_request_interface=URLRequestInterface(),
         html_parser=HTMLResponseParser(
             root_url_cache=RootURLCache()
+        ),
+        discord_poster=DiscordPoster(
+            webhook_url=get_from_env("DISCORD_WEBHOOK_URL")
         )
     )
     async_scheduled_task_manager = AsyncScheduledTaskManager(async_core=async_core)

--- a/tests/test_automated/integration/api/conftest.py
+++ b/tests/test_automated/integration/api/conftest.py
@@ -30,7 +30,8 @@ def override_access_info() -> AccessInfo:
     return AccessInfo(user_id=MOCK_USER_ID, permissions=[Permissions.SOURCE_COLLECTOR])
 
 @pytest.fixture
-def client(db_client_test) -> Generator[TestClient, None, None]:
+def client(db_client_test, monkeypatch) -> Generator[TestClient, None, None]:
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.com")
     with TestClient(app) as c:
         app.dependency_overrides[get_access_info] = override_access_info
         core: SourceCollectorCore = c.app.state.core

--- a/tests/test_automated/integration/security_manager/test_security_manager.py
+++ b/tests/test_automated/integration/security_manager/test_security_manager.py
@@ -18,12 +18,16 @@ SECRET_KEY = "test_secret_key"
 VALID_TOKEN = "valid_token"
 INVALID_TOKEN = "invalid_token"
 FAKE_PAYLOAD = {
-    "sub": 1,
+    "sub": "1",
     "permissions": [Permissions.SOURCE_COLLECTOR.value]
 }
 
-def test_api_with_valid_token(mock_get_secret_key):
+def test_api_with_valid_token(
+        mock_get_secret_key,
+        monkeypatch
+):
 
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.com")
     token = jwt.encode(FAKE_PAYLOAD, SECRET_KEY, algorithm=ALGORITHM)
 
     # Create Test Client

--- a/util/DiscordNotifier.py
+++ b/util/DiscordNotifier.py
@@ -1,0 +1,13 @@
+import logging
+
+import requests
+
+
+class DiscordPoster:
+    def __init__(self, webhook_url: str):
+        if not webhook_url:
+            logging.error("WEBHOOK_URL environment variable not set")
+            raise ValueError("WEBHOOK_URL environment variable not set")
+        self.webhook_url = webhook_url
+    def post_to_discord(self, message):
+        requests.post(self.webhook_url, json={"content": message})


### PR DESCRIPTION
https://github.com/Police-Data-Accessibility-Project/data-source-identification/issues/204

The task loop has been modified such that, if prerequisites continue to be met, the same task loop will run again.

In the case of the task looping more than 20 times, the task loop is set to break and discord notified as an indicator of potentially unwelcome activity.