### PR TITLE
feat(api): adjust final review to reflect single user annotations

### DIFF
--- a/collector_db/models.py
+++ b/collector_db/models.py
@@ -119,16 +119,16 @@ class URL(Base):
     )
     automated_agency_suggestions = relationship(
         "AutomatedUrlAgencySuggestion", back_populates="url")
-    user_agency_suggestions = relationship(
-        "UserUrlAgencySuggestion", back_populates="url")
+    user_agency_suggestion = relationship(
+        "UserUrlAgencySuggestion", uselist=False, back_populates="url")
     auto_record_type_suggestion = relationship(
         "AutoRecordTypeSuggestion", uselist=False, back_populates="url")
-    user_record_type_suggestions = relationship(
-        "UserRecordTypeSuggestion", back_populates="url")
+    user_record_type_suggestion = relationship(
+        "UserRecordTypeSuggestion", uselist=False, back_populates="url")
     auto_relevant_suggestion = relationship(
         "AutoRelevantSuggestion", uselist=False, back_populates="url")
-    user_relevant_suggestions = relationship(
-        "UserRelevantSuggestion", back_populates="url")
+    user_relevant_suggestion = relationship(
+        "UserRelevantSuggestion", uselist=False, back_populates="url")
     reviewing_user = relationship(
         "ReviewingUserURL", uselist=False, back_populates="url")
     optional_data_source_metadata = relationship(
@@ -375,7 +375,7 @@ class UserUrlAgencySuggestion(Base):
     is_new = Column(Boolean, nullable=True)
 
     agency = relationship("Agency", back_populates="user_suggestions")
-    url = relationship("URL", back_populates="user_agency_suggestions")
+    url = relationship("URL", back_populates="user_agency_suggestion")
 
     __table_args__ = (
         UniqueConstraint("agency_id", "url_id", "user_id", name="uq_user_url_agency_suggestions"),
@@ -432,7 +432,7 @@ class UserRelevantSuggestion(Base):
 
     # Relationships
 
-    url = relationship("URL", back_populates="user_relevant_suggestions")
+    url = relationship("URL", back_populates="user_relevant_suggestion")
 
 
 class UserRecordTypeSuggestion(Base):
@@ -451,4 +451,4 @@ class UserRecordTypeSuggestion(Base):
 
     # Relationships
 
-    url = relationship("URL", back_populates="user_record_type_suggestions")
+    url = relationship("URL", back_populates="user_record_type_suggestion")

--- a/core/DTOs/GetNextURLForFinalReviewResponse.py
+++ b/core/DTOs/GetNextURLForFinalReviewResponse.py
@@ -6,26 +6,21 @@ from core.DTOs.GetNextURLForAgencyAnnotationResponse import GetNextURLForAgencyA
 from core.enums import RecordType
 from html_tag_collector.DataClassTags import ResponseHTMLInfo
 
-
-class FinalReviewAnnotationRelevantUsersInfo(BaseModel):
-    relevant: int = Field(title="Number of users who marked the URL as relevant")
-    not_relevant: int = Field(title="Number of users who marked the URL as not relevant")
-
 class FinalReviewAnnotationRelevantInfo(BaseModel):
     auto: Optional[bool] = Field(title="Whether the auto-labeler has marked the URL as relevant")
-    users: FinalReviewAnnotationRelevantUsersInfo = Field(
-        title="How users identified the relevancy of the source",
+    user: Optional[bool] = Field(
+        title="Whether a user has marked the URL as relevant",
     )
 
 class FinalReviewAnnotationRecordTypeInfo(BaseModel):
-    auto: Optional[RecordType] = Field(title="The record type suggested by the auto-labeler")
-    users: dict[RecordType, int] = Field(
-        title="A dictionary, sorted by size and omitting zero values, of all record types suggested by users",
+    auto: Optional[RecordType] = Field(
+        title="The record type suggested by the auto-labeler"
+    )
+    user: Optional[RecordType] = Field(
+        title="The record type suggested by a user",
     )
 
 # region Agency
-class FinalReviewAnnotationAgencyUserInfo(GetNextURLForAgencyAgencyInfo):
-    count: int = Field(title="Number of times suggested by users")
 
 class FinalReviewAnnotationAgencyAutoInfo(BaseModel):
     unknown: bool = Field(title="Whether the auto-labeler suggested the URL as unknown")
@@ -39,8 +34,8 @@ class FinalReviewAnnotationAgencyInfo(BaseModel):
     )
     auto: Optional[FinalReviewAnnotationAgencyAutoInfo] = Field(
         title="A single agency or a list of agencies suggested by the auto-labeler",)
-    users: Optional[dict[int, FinalReviewAnnotationAgencyUserInfo]] = Field(
-        title="A list, sorted by size, of all agencies suggested by users",
+    user: Optional[GetNextURLForAgencyAgencyInfo] = Field(
+        title="A single agency suggested by a user",
     )
 # endregion
 

--- a/tests/test_automated/integration/api/test_review.py
+++ b/tests/test_automated/integration/api/test_review.py
@@ -46,14 +46,11 @@ async def test_review_next_source(api_test_helper):
     annotation_info = result.annotations
     relevant_info = annotation_info.relevant
     assert relevant_info.auto == True
-    assert relevant_info.users.not_relevant == 1
+    assert relevant_info.user == False
 
     record_type_info = annotation_info.record_type
     assert record_type_info.auto == RecordType.ARREST_RECORDS
-    user_d = record_type_info.users
-    assert user_d[RecordType.ACCIDENT_REPORTS] == 1
-    assert list(user_d.keys()) == [RecordType.ACCIDENT_REPORTS]
-
+    assert record_type_info.user == RecordType.ACCIDENT_REPORTS
 
     agency_info = annotation_info.agency
     auto_agency_suggestions = agency_info.auto
@@ -61,9 +58,9 @@ async def test_review_next_source(api_test_helper):
     assert len(auto_agency_suggestions.suggestions) == 3
 
     # Check user agency suggestions exist and in descending order of count
-    user_agency_suggestions = agency_info.users
-    user_agency_suggestions_as_list = list(user_agency_suggestions.values())
-    assert len(user_agency_suggestions_as_list) == 1
+    user_agency_suggestion = agency_info.user
+    assert user_agency_suggestion.pdap_agency_id == setup_info.user_agency_id
+
 
     # Check confirmed agencies exist
     confirmed_agencies = agency_info.confirmed
@@ -78,13 +75,12 @@ async def test_approve_and_get_next_source_for_review(api_test_helper):
 
     setup_info = await setup_for_get_next_url_for_final_review(
         db_data_creator=db_data_creator,
-        annotation_count=3,
         include_user_annotations=True
     )
     url_mapping = setup_info.url_mapping
 
     # Add confirmed agency
-    confirmed_agency = await db_data_creator.confirmed_suggestions([url_mapping.url_id])
+    await db_data_creator.confirmed_suggestions([url_mapping.url_id])
 
     # Additionally, include an agency not yet included in the database
     additional_agency = 999999

--- a/tests/test_automated/integration/collector_db/test_db_client.py
+++ b/tests/test_automated/integration/collector_db/test_db_client.py
@@ -186,24 +186,20 @@ async def test_get_next_url_for_final_review_basic(db_data_creator: DBDataCreato
     annotation_info = result.annotations
     relevant_info = annotation_info.relevant
     assert relevant_info.auto == True
-    assert relevant_info.users.not_relevant == 1
+    assert relevant_info.user == False
 
     record_type_info = annotation_info.record_type
     assert record_type_info.auto == RecordType.ARREST_RECORDS
-    user_d = record_type_info.users
-    assert user_d[RecordType.ACCIDENT_REPORTS] == 1
-    assert list(user_d.keys()) == [RecordType.ACCIDENT_REPORTS]
-
+    assert record_type_info.user == RecordType.ACCIDENT_REPORTS
 
     agency_info = annotation_info.agency
     auto_agency_suggestions = agency_info.auto
     assert auto_agency_suggestions.unknown == False
     assert len(auto_agency_suggestions.suggestions) == 3
 
-    # Check user agency suggestions exist and in descending order of count
-    user_agency_suggestions = agency_info.users
-    user_agency_suggestions_as_list = list(user_agency_suggestions.values())
-    assert len(user_agency_suggestions_as_list) == 1
+    # Check user agency suggestion exists and is correct
+    assert agency_info.user.pdap_agency_id == setup_info.user_agency_id
+
 
 @pytest.mark.asyncio
 async def test_get_next_url_for_final_review_batch_id_filtering(db_data_creator: DBDataCreator):
@@ -301,12 +297,11 @@ async def test_get_next_url_for_final_review_no_annotations(db_data_creator: DBD
 
     record_type = annotations.record_type
     assert record_type.auto is None
-    assert record_type.users == {}
+    assert record_type.user is None
 
     relevant = annotations.relevant
     assert relevant.auto is None
-    assert relevant.users.relevant == 0
-    assert relevant.users.not_relevant == 0
+    assert relevant.user is None
 
 @pytest.mark.asyncio
 async def test_get_next_url_for_final_review_only_confirmed_urls(db_data_creator: DBDataCreator):


### PR DESCRIPTION
https://github.com/Police-Data-Accessibility-Project/data-source-identification/issues/226

Previously, the final review showed multiple user annotations for a URL. Now, because each URL can only have one user for each type of annotation, the endpoint has been updated.