### PR TITLE
Mc 223 relevancy labeling

### DIFF
--- a/alembic/versions/2025_05_16_1031-00cc949e0347_update_relevancy_logic.py
+++ b/alembic/versions/2025_05_16_1031-00cc949e0347_update_relevancy_logic.py
@@ -1,0 +1,160 @@
+"""Update relevancy logic
+
+- Add new status to URL Status outcome: `individual record`
+- Change URL Status value `rejected` to `not relevant` , for specificity
+- Create `user_suggested_status` enum
+- ` Add `suggested_status` column to `user_relevant_suggestions`
+- Migrate `user_relevant_suggestions:relevant` to `user_relevant_suggestions:user_suggested_status`
+
+Revision ID: 00cc949e0347
+Revises: b5f079b6b8cb
+Create Date: 2025-05-16 10:31:04.417203
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+from util.alembic_helpers import switch_enum_type
+
+# revision identifiers, used by Alembic.
+revision: str = '00cc949e0347'
+down_revision: Union[str, None] = 'b5f079b6b8cb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+suggested_status_enum = sa.Enum(
+    'relevant',
+    'not relevant',
+    'individual record',
+    'broken page/404 not found',
+    name='user_suggested_status'
+)
+
+def upgrade() -> None:
+    # Replace `relevant` column with `suggested_status` column
+    op.add_column(
+        'user_relevant_suggestions',
+        sa.Column(
+            'suggested_status',
+            suggested_status_enum,
+            nullable=True
+        )
+    )
+    # Migrate existing entries
+    op.execute("""
+        UPDATE user_relevant_suggestions
+        SET suggested_status = 'relevant'
+        WHERE relevant = true
+    """)
+    op.execute("""
+        UPDATE user_relevant_suggestions
+        SET suggested_status = 'not relevant'
+        WHERE relevant = false
+    """)
+    op.alter_column(
+        'user_relevant_suggestions',
+        'suggested_status',
+        nullable=False
+    )
+    op.drop_column(
+        'user_relevant_suggestions',
+        'relevant'
+    )
+
+    # Update `url_status` enum to include
+    # `individual record`
+    # And change `rejected` to `not relevant`
+    op.execute("""
+    ALTER TYPE url_status RENAME VALUE 'rejected' TO 'not relevant';
+    """)
+    switch_enum_type(
+        table_name='urls',
+        column_name='outcome',
+        enum_name='url_status',
+        new_enum_values=[
+            'pending',
+            'submitted',
+            'validated',
+            'duplicate',
+            'not relevant',
+            'error',
+            '404 not found',
+            'individual record'
+        ],
+        check_constraints_to_drop=['url_name_not_null_when_validated']
+    )
+    op.execute(
+    """
+    ALTER TABLE urls
+        ADD CONSTRAINT url_name_not_null_when_validated
+            CHECK ((name IS NOT NULL) OR (outcome <> 'validated'::url_status))
+           """
+    )
+
+
+def downgrade() -> None:
+    # Update `url_status` enum to remove
+    # `individual record`
+    # And change `not relevant` to `rejected`
+    op.execute("""
+    ALTER TYPE url_status RENAME VALUE 'not relevant' TO 'rejected';
+    """)
+    op.execute("""
+    UPDATE urls
+    SET outcome = 'not relevant'
+    WHERE outcome = 'individual record'
+    """)
+    switch_enum_type(
+        table_name='urls',
+        column_name='outcome',
+        enum_name='url_status',
+        new_enum_values=[
+            'pending',
+            'submitted',
+            'validated',
+            'duplicate',
+            'not relevant',
+            'error',
+            '404 not found',
+        ],
+        check_constraints_to_drop=['url_name_not_null_when_validated']
+    )
+    op.execute(
+    """
+    ALTER TABLE urls
+        ADD CONSTRAINT url_name_not_null_when_validated
+            CHECK ((name IS NOT NULL) OR (outcome <> 'validated'::url_status))
+           """
+    )
+
+    # Replace `suggested_status` column with `relevant` column
+    op.add_column(
+        'user_relevant_suggestions',
+        sa.Column(
+            'relevant',
+            sa.BOOLEAN(),
+            nullable=True
+        )
+    )
+    op.execute("""
+        UPDATE user_relevant_suggestions
+        SET relevant = true
+        WHERE suggested_status = 'relevant'
+    """)
+    op.execute("""
+        UPDATE user_relevant_suggestions
+        SET relevant = false
+        WHERE suggested_status = 'not relevant'
+    """)
+    op.alter_column(
+        'user_relevant_suggestions',
+        'relevant',
+        nullable=False
+    )
+    op.drop_column(
+        'user_relevant_suggestions',
+        'suggested_status'
+    )

--- a/alembic/versions/2025_05_16_1031-00cc949e0347_update_relevancy_logic.py
+++ b/alembic/versions/2025_05_16_1031-00cc949e0347_update_relevancy_logic.py
@@ -30,10 +30,11 @@ suggested_status_enum = sa.Enum(
     'not relevant',
     'individual record',
     'broken page/404 not found',
-    name='user_suggested_status'
+    name='suggested_status'
 )
 
 def upgrade() -> None:
+    suggested_status_enum.create(op.get_bind())
     # Replace `relevant` column with `suggested_status` column
     op.add_column(
         'user_relevant_suggestions',
@@ -104,7 +105,7 @@ def downgrade() -> None:
     """)
     op.execute("""
     UPDATE urls
-    SET outcome = 'not relevant'
+    SET outcome = 'rejected'
     WHERE outcome = 'individual record'
     """)
     switch_enum_type(
@@ -116,7 +117,7 @@ def downgrade() -> None:
             'submitted',
             'validated',
             'duplicate',
-            'not relevant',
+            'rejected',
             'error',
             '404 not found',
         ],
@@ -158,3 +159,4 @@ def downgrade() -> None:
         'user_relevant_suggestions',
         'suggested_status'
     )
+    suggested_status_enum.drop(op.get_bind(), checkfirst=True)

--- a/api/routes/annotate.py
+++ b/api/routes/annotate.py
@@ -55,7 +55,7 @@ async def annotate_url_for_relevance_and_get_next_url(
     await async_core.submit_url_relevance_annotation(
         user_id=access_info.user_id,
         url_id=url_id,
-        relevant=relevance_annotation_post_info.is_relevant
+        suggested_status=relevance_annotation_post_info.suggested_status
     )
     return await async_core.get_next_url_for_relevance_annotation(
         user_id=access_info.user_id,

--- a/api/routes/review.py
+++ b/api/routes/review.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query
 
 from api.dependencies import get_async_core
 from core.AsyncCore import AsyncCore
-from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo, FinalReviewBaseInfo
+from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo, FinalReviewBaseInfo, FinalReviewRejectionInfo
 from core.DTOs.GetNextURLForFinalReviewResponse import GetNextURLForFinalReviewResponse, \
     GetNextURLForFinalReviewOuterResponse
 from security_manager.SecurityManager import AccessInfo, get_access_info, require_permission, Permissions
@@ -50,7 +50,7 @@ async def approve_source(
 async def reject_source(
     core: AsyncCore = Depends(get_async_core),
     access_info: AccessInfo = Depends(requires_final_review_permission),
-    review_info: FinalReviewBaseInfo = FinalReviewBaseInfo,
+    review_info: FinalReviewRejectionInfo = FinalReviewRejectionInfo,
     batch_id: Optional[int] = Query(
         description="The batch id of the next URL to get. "
                     "If not specified, defaults to first qualifying URL",
@@ -59,6 +59,7 @@ async def reject_source(
     await core.reject_url(
         url_id=review_info.url_id,
         access_info=access_info,
+        rejection_reason=review_info.rejection_reason
     )
     next_source = await core.get_next_source_for_review(batch_id=batch_id)
     return GetNextURLForFinalReviewOuterResponse(next_source=next_source)

--- a/collector_db/AsyncDatabaseClient.py
+++ b/collector_db/AsyncDatabaseClient.py
@@ -1299,7 +1299,7 @@ class AsyncDatabaseClient:
         url = await session.execute(query)
         url = url.scalars().first()
 
-        url.outcome = URLStatus.REJECTED.value
+        url.outcome = URLStatus.NOT_RELEVANT.value
 
         # Add rejecting user
         rejecting_user_url = ReviewingUserURL(
@@ -1872,7 +1872,7 @@ class AsyncDatabaseClient:
             url_column(URLStatus.ERROR, label="error_count"),
             url_column(URLStatus.VALIDATED, label="validated_count"),
             url_column(URLStatus.SUBMITTED, label="submitted_count"),
-            url_column(URLStatus.REJECTED, label="rejected_count"),
+            url_column(URLStatus.NOT_RELEVANT, label="rejected_count"),
 
         ).outerjoin(
             Batch, Batch.id == URL.batch_id
@@ -1957,7 +1957,7 @@ class AsyncDatabaseClient:
             sc.count_distinct(URL.id, label="count_total"),
             url_column(URLStatus.PENDING, label="count_pending"),
             url_column(URLStatus.SUBMITTED, label="count_submitted"),
-            url_column(URLStatus.REJECTED, label="count_rejected"),
+            url_column(URLStatus.NOT_RELEVANT, label="count_rejected"),
             url_column(URLStatus.ERROR, label="count_error"),
             url_column(URLStatus.VALIDATED, label="count_validated"),
         ).group_by(
@@ -2075,7 +2075,7 @@ class AsyncDatabaseClient:
             case_column(URLStatus.PENDING, label="count_pending"),
             case_column(URLStatus.SUBMITTED, label="count_submitted"),
             case_column(URLStatus.VALIDATED, label="count_validated"),
-            case_column(URLStatus.REJECTED, label="count_rejected"),
+            case_column(URLStatus.NOT_RELEVANT, label="count_rejected"),
             case_column(URLStatus.ERROR, label="count_error"),
         )
         raw_results = await session.execute(count_query)

--- a/collector_db/DTOConverter.py
+++ b/collector_db/DTOConverter.py
@@ -26,7 +26,7 @@ class DTOConverter:
     ) -> FinalReviewAnnotationRelevantInfo:
 
         auto_value = auto_suggestion.relevant if auto_suggestion else None
-        user_value = user_suggestion.relevant if user_suggestion else None
+        user_value = user_suggestion.suggested_status if user_suggestion else None
         return FinalReviewAnnotationRelevantInfo(
             auto=auto_value,
             user=user_value

--- a/collector_db/models.py
+++ b/collector_db/models.py
@@ -96,10 +96,11 @@ class URL(Base):
             'pending',
             'submitted',
             'validated',
-            'rejected',
+            'not relevant',
             'duplicate',
             'error',
             '404 not found',
+            'individual record',
             name='url_status'
         ),
         nullable=False
@@ -457,7 +458,16 @@ class UserRelevantSuggestion(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     url_id = Column(Integer, ForeignKey("urls.id"), nullable=False)
     user_id = Column(Integer, nullable=False)
-    relevant = Column(Boolean, nullable=False)
+    suggested_status = Column(
+        postgresql.ENUM(
+            'relevant',
+            'not relevant',
+            'individual record',
+            'broken page/404 not found',
+            name='suggested_status'
+        ),
+        nullable=True
+    )
     created_at = get_created_at_column()
     updated_at = get_updated_at_column()
 

--- a/collector_manager/enums.py
+++ b/collector_manager/enums.py
@@ -16,5 +16,6 @@ class URLStatus(Enum):
     VALIDATED = "validated"
     ERROR = "error"
     DUPLICATE = "duplicate"
-    REJECTED = "rejected"
+    NOT_RELEVANT = "not relevant"
     NOT_FOUND = "404 not found"
+    INDIVIDUAL_RECORD = "individual record"

--- a/core/AsyncCore.py
+++ b/core/AsyncCore.py
@@ -11,7 +11,7 @@ from collector_manager.AsyncCollectorManager import AsyncCollectorManager
 from collector_manager.enums import CollectorType
 from core.DTOs.AllAnnotationPostInfo import AllAnnotationPostInfo
 from core.DTOs.CollectorStartInfo import CollectorStartInfo
-from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo
+from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo, RejectionReason
 from core.DTOs.GetBatchLogsResponse import GetBatchLogsResponse
 from core.DTOs.GetBatchStatusResponse import GetBatchStatusResponse
 from core.DTOs.GetDuplicatesByBatchResponse import GetDuplicatesByBatchResponse
@@ -35,7 +35,7 @@ from core.DTOs.MessageResponse import MessageResponse
 from core.DTOs.SearchURLResponse import SearchURLResponse
 from core.TaskManager import TaskManager
 from core.classes.ErrorManager import ErrorManager
-from core.enums import BatchStatus, RecordType, AnnotationType
+from core.enums import BatchStatus, RecordType, AnnotationType, SuggestedStatus
 
 from security_manager.SecurityManager import AccessInfo
 
@@ -155,13 +155,13 @@ class AsyncCore:
             self,
             user_id: int,
             url_id: int,
-            relevant: bool
+            suggested_status: SuggestedStatus
     ):
         try:
             return await self.adb_client.add_user_relevant_suggestion(
                 user_id=user_id,
                 url_id=url_id,
-                relevant=relevant
+                suggested_status=suggested_status
             )
         except IntegrityError as e:
             return await ErrorManager.raise_annotation_exists_error(
@@ -287,10 +287,12 @@ class AsyncCore:
             self,
             url_id: int,
             access_info: AccessInfo,
+            rejection_reason: RejectionReason
     ):
         await self.adb_client.reject_url(
             url_id=url_id,
-            user_id=access_info.user_id
+            user_id=access_info.user_id,
+            rejection_reason=rejection_reason
         )
 
     async def upload_manual_batch(

--- a/core/DTOs/AllAnnotationPostInfo.py
+++ b/core/DTOs/AllAnnotationPostInfo.py
@@ -5,31 +5,31 @@ from fastapi import HTTPException
 from pydantic import BaseModel, model_validator
 
 from core.DTOs.GetNextURLForAgencyAnnotationResponse import URLAgencyAnnotationPostInfo
-from core.enums import RecordType
+from core.enums import RecordType, SuggestedStatus
 from core.exceptions import FailedValidationException
 
 
 class AllAnnotationPostInfo(BaseModel):
-    is_relevant: bool
+    suggested_status: SuggestedStatus
     record_type: Optional[RecordType] = None
     agency: Optional[URLAgencyAnnotationPostInfo] = None
 
-    @model_validator(mode="before")
-    def allow_record_type_and_agency_only_if_relevant(cls, values):
-        is_relevant = values.get("is_relevant")
-        record_type = values.get("record_type")
-        agency = values.get("agency")
+    @model_validator(mode="after")
+    def allow_record_type_and_agency_only_if_relevant(self):
+        suggested_status = self.suggested_status
+        record_type = self.record_type
+        agency = self.agency
 
-        if not is_relevant:
+        if suggested_status != SuggestedStatus.RELEVANT:
             if record_type is not None:
-                raise FailedValidationException("record_type must be None if is_relevant is False")
+                raise FailedValidationException("record_type must be None if suggested_status is not relevant")
 
             if agency is not None:
-                raise FailedValidationException("agency must be None if is_relevant is False")
-            return values
+                raise FailedValidationException("agency must be None if suggested_status is not relevant")
+            return self
         # Similarly, if relevant, record_type and agency must be provided
         if record_type is None:
-            raise FailedValidationException("record_type must be provided if is_relevant is True")
+            raise FailedValidationException("record_type must be provided if suggested_status is relevant")
         if agency is None:
-            raise FailedValidationException("agency must be provided if is_relevant is True")
-        return values
+            raise FailedValidationException("agency must be provided if suggested_status is relevant")
+        return self

--- a/core/DTOs/FinalReviewApprovalInfo.py
+++ b/core/DTOs/FinalReviewApprovalInfo.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -8,6 +9,14 @@ class FinalReviewBaseInfo(BaseModel):
     url_id: int = Field(
         title="The id of the URL."
     )
+
+class RejectionReason(Enum):
+    NOT_RELEVANT = "NOT_RELEVANT"
+    BROKEN_PAGE_404 = "BROKEN_PAGE"
+    INDIVIDUAL_RECORD = "INDIVIDUAL_RECORD"
+
+class FinalReviewRejectionInfo(FinalReviewBaseInfo):
+    rejection_reason: RejectionReason = RejectionReason.NOT_RELEVANT
 
 class FinalReviewApprovalInfo(FinalReviewBaseInfo):
     record_type: Optional[RecordType] = Field(

--- a/core/DTOs/GetNextURLForFinalReviewResponse.py
+++ b/core/DTOs/GetNextURLForFinalReviewResponse.py
@@ -3,13 +3,13 @@ from typing import Optional
 from pydantic import BaseModel, Field
 
 from core.DTOs.GetNextURLForAgencyAnnotationResponse import GetNextURLForAgencyAgencyInfo
-from core.enums import RecordType
+from core.enums import RecordType, SuggestedStatus
 from html_tag_collector.DataClassTags import ResponseHTMLInfo
 
 class FinalReviewAnnotationRelevantInfo(BaseModel):
     auto: Optional[bool] = Field(title="Whether the auto-labeler has marked the URL as relevant")
-    user: Optional[bool] = Field(
-        title="Whether a user has marked the URL as relevant",
+    user: Optional[SuggestedStatus] = Field(
+        title="The status marked by a user, if any",
     )
 
 class FinalReviewAnnotationRecordTypeInfo(BaseModel):

--- a/core/DTOs/RelevanceAnnotationPostInfo.py
+++ b/core/DTOs/RelevanceAnnotationPostInfo.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
 
+from core.enums import SuggestedStatus
+
 
 class RelevanceAnnotationPostInfo(BaseModel):
-    is_relevant: bool
+    suggested_status: SuggestedStatus

--- a/core/enums.py
+++ b/core/enums.py
@@ -71,3 +71,12 @@ class SubmitResponseStatus(Enum):
     SUCCESS = "success"
     FAILURE = "FAILURE"
     ALREADY_EXISTS = "already_exists"
+
+class SuggestedStatus(Enum):
+    """
+    Possible values for user_relevant_suggestions:suggested_status
+    """
+    RELEVANT = "relevant"
+    NOT_RELEVANT = "not relevant"
+    INDIVIDUAL_RECORD = "individual record"
+    BROKEN_PAGE_404 = "broken page/404 not found"

--- a/tests/helpers/DBDataCreator.py
+++ b/tests/helpers/DBDataCreator.py
@@ -221,6 +221,13 @@ class DBDataCreator:
             relevant=relevant
         )
 
+    async def user_relevant_suggestion_v2(
+            self,
+            url_id: int,
+            user_id: Optional[int] = None,
+
+    )
+
     async def user_record_type_suggestion(
             self,
             url_id: int,

--- a/tests/helpers/DBDataCreator.py
+++ b/tests/helpers/DBDataCreator.py
@@ -16,7 +16,7 @@ from collector_db.DTOs.URLMapping import URLMapping
 from collector_db.DatabaseClient import DatabaseClient
 from collector_db.enums import TaskType
 from collector_manager.enums import CollectorType, URLStatus
-from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo
+from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo, RejectionReason
 from core.DTOs.URLAgencySuggestionInfo import URLAgencySuggestionInfo
 from core.DTOs.task_data_objects.SubmitApprovedURLTDO import SubmittedURLInfo
 from core.DTOs.task_data_objects.URLMiscellaneousMetadataTDO import URLMiscellaneousMetadataTDO
@@ -203,7 +203,8 @@ class DBDataCreator:
             else:
                 await self.adb_client.reject_url(
                     url_id=url_id,
-                    user_id=1
+                    user_id=1,
+                    rejection_reason=RejectionReason.NOT_RELEVANT
                 )
 
 

--- a/tests/helpers/DBDataCreator.py
+++ b/tests/helpers/DBDataCreator.py
@@ -20,7 +20,7 @@ from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo
 from core.DTOs.URLAgencySuggestionInfo import URLAgencySuggestionInfo
 from core.DTOs.task_data_objects.SubmitApprovedURLTDO import SubmittedURLInfo
 from core.DTOs.task_data_objects.URLMiscellaneousMetadataTDO import URLMiscellaneousMetadataTDO
-from core.enums import BatchStatus, SuggestionType, RecordType
+from core.enums import BatchStatus, SuggestionType, RecordType, SuggestedStatus
 from tests.helpers.test_batch_creation_parameters import TestBatchCreationParameters, AnnotationInfo
 from tests.helpers.simple_test_data_functions import generate_test_urls
 
@@ -175,7 +175,7 @@ class DBDataCreator:
     async def annotate(self, url_id: int, annotation_info: AnnotationInfo):
         info = annotation_info
         if info.user_relevant is not None:
-            await self.user_relevant_suggestion(url_id=url_id, relevant=info.user_relevant)
+            await self.user_relevant_suggestion_v2(url_id=url_id, suggested_status=info.user_relevant)
         if info.auto_relevant is not None:
             await self.auto_relevant_suggestions(url_id=url_id, relevant=info.auto_relevant)
         if info.user_record_type is not None:
@@ -213,20 +213,25 @@ class DBDataCreator:
             user_id: Optional[int] = None,
             relevant: bool = True
     ):
-        if user_id is None:
-            user_id = randint(1, 99999999)
-        await self.adb_client.add_user_relevant_suggestion(
+        await self.user_relevant_suggestion_v2(
             url_id=url_id,
             user_id=user_id,
-            relevant=relevant
+            suggested_status=SuggestedStatus.RELEVANT if relevant else SuggestedStatus.NOT_RELEVANT
         )
 
     async def user_relevant_suggestion_v2(
             self,
             url_id: int,
             user_id: Optional[int] = None,
-
-    )
+            suggested_status: SuggestedStatus = SuggestedStatus.RELEVANT
+    ):
+        if user_id is None:
+            user_id = randint(1, 99999999)
+        await self.adb_client.add_user_relevant_suggestion(
+            url_id=url_id,
+            user_id=user_id,
+            suggested_status=suggested_status
+        )
 
     async def user_record_type_suggestion(
             self,

--- a/tests/helpers/test_batch_creation_parameters.py
+++ b/tests/helpers/test_batch_creation_parameters.py
@@ -37,7 +37,7 @@ class TestURLCreationParameters(BaseModel):
 
     @model_validator(mode='after')
     def validate_annotation_info(self):
-        if self.status == URLStatus.REJECTED:
+        if self.status == URLStatus.NOT_RELEVANT:
             self.annotation_info.final_review_approved = False
             return self
         if self.status != URLStatus.VALIDATED:

--- a/tests/helpers/test_batch_creation_parameters.py
+++ b/tests/helpers/test_batch_creation_parameters.py
@@ -4,11 +4,11 @@ from typing import Optional
 from pydantic import BaseModel, model_validator
 
 from collector_manager.enums import URLStatus, CollectorType
-from core.enums import BatchStatus, AnnotationType, RecordType
+from core.enums import BatchStatus, AnnotationType, RecordType, SuggestedStatus
 
 
 class AnnotationInfo(BaseModel):
-    user_relevant: Optional[bool] = None
+    user_relevant: Optional[SuggestedStatus] = None
     auto_relevant: Optional[bool] = None
     user_record_type: Optional[RecordType] = None
     auto_record_type: Optional[RecordType] = None

--- a/tests/test_automated/integration/api/helpers/RequestValidator.py
+++ b/tests/test_automated/integration/api/helpers/RequestValidator.py
@@ -12,7 +12,7 @@ from collector_db.enums import TaskType
 from collector_manager.DTOs.ExampleInputDTO import ExampleInputDTO
 from collector_manager.enums import CollectorType
 from core.DTOs.AllAnnotationPostInfo import AllAnnotationPostInfo
-from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo, FinalReviewBaseInfo
+from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo, FinalReviewBaseInfo, FinalReviewRejectionInfo
 from core.DTOs.GetBatchLogsResponse import GetBatchLogsResponse
 from core.DTOs.GetBatchStatusResponse import GetBatchStatusResponse
 from core.DTOs.GetDuplicatesByBatchResponse import GetDuplicatesByBatchResponse
@@ -350,7 +350,7 @@ class RequestValidator:
 
     async def reject_and_get_next_source_for_review(
             self,
-            review_info: FinalReviewBaseInfo
+            review_info: FinalReviewRejectionInfo
     ) -> GetNextURLForFinalReviewOuterResponse:
         data = self.post(
             url=f"/review/reject-source",

--- a/tests/test_automated/integration/api/test_metrics.py
+++ b/tests/test_automated/integration/api/test_metrics.py
@@ -26,7 +26,7 @@ async def test_get_batches_aggregated_metrics(api_test_helper):
                 ),
                 TestURLCreationParameters(
                     count=3,
-                    status=URLStatus.REJECTED
+                    status=URLStatus.NOT_RELEVANT
                 ),
                 TestURLCreationParameters(
                     count=4,
@@ -106,7 +106,7 @@ async def test_get_batches_breakdown_metrics(api_test_helper):
         urls=[
             TestURLCreationParameters(
                 count=3,
-                status=URLStatus.REJECTED
+                status=URLStatus.NOT_RELEVANT
             ),
             TestURLCreationParameters(
                 count=4,
@@ -363,7 +363,7 @@ async def test_get_urls_aggregate_metrics(api_test_helper):
             ),
             TestURLCreationParameters(
                 count=5,
-                status=URLStatus.REJECTED
+                status=URLStatus.NOT_RELEVANT
             ),
         ]
     )

--- a/tests/test_automated/integration/api/test_metrics.py
+++ b/tests/test_automated/integration/api/test_metrics.py
@@ -2,7 +2,7 @@ import pendulum
 import pytest
 
 from collector_manager.enums import URLStatus, CollectorType
-from core.enums import BatchStatus, RecordType
+from core.enums import BatchStatus, RecordType, SuggestedStatus
 from tests.helpers.test_batch_creation_parameters import TestBatchCreationParameters, TestURLCreationParameters, \
     AnnotationInfo
 
@@ -247,7 +247,7 @@ async def test_get_urls_breakdown_pending_metrics(api_test_helper):
                 count=1,
                 status=URLStatus.PENDING,
                 annotation_info=AnnotationInfo(
-                    user_relevant=False
+                    user_relevant=SuggestedStatus.NOT_RELEVANT
                 )
             ),
             TestURLCreationParameters(
@@ -264,7 +264,7 @@ async def test_get_urls_breakdown_pending_metrics(api_test_helper):
                 count=3,
                 status=URLStatus.PENDING,
                 annotation_info=AnnotationInfo(
-                    user_relevant=True,
+                    user_relevant=SuggestedStatus.RELEVANT,
                     user_record_type=RecordType.CALLS_FOR_SERVICE
                 )
             )
@@ -288,7 +288,7 @@ async def test_get_urls_breakdown_pending_metrics(api_test_helper):
                 count=5,
                 status=URLStatus.PENDING,
                 annotation_info=AnnotationInfo(
-                    user_relevant=True,
+                    user_relevant=SuggestedStatus.RELEVANT,
                     user_record_type=RecordType.INCARCERATION_RECORDS,
                     user_agency=agency_id
                 )
@@ -401,7 +401,7 @@ async def test_get_backlog_metrics(api_test_helper):
                 count=1,
                 status=URLStatus.PENDING,
                 annotation_info=AnnotationInfo(
-                    user_relevant=False
+                    user_relevant=SuggestedStatus.NOT_RELEVANT
                 )
             ),
             TestURLCreationParameters(
@@ -427,7 +427,7 @@ async def test_get_backlog_metrics(api_test_helper):
                 count=4,
                 status=URLStatus.PENDING,
                 annotation_info=AnnotationInfo(
-                    user_relevant=False
+                    user_relevant=SuggestedStatus.NOT_RELEVANT
                 )
             ),
             TestURLCreationParameters(
@@ -453,7 +453,7 @@ async def test_get_backlog_metrics(api_test_helper):
                 count=7,
                 status=URLStatus.PENDING,
                 annotation_info=AnnotationInfo(
-                    user_relevant=False
+                    user_relevant=SuggestedStatus.NOT_RELEVANT
                 )
             ),
             TestURLCreationParameters(

--- a/tests/test_automated/integration/api/test_review.py
+++ b/tests/test_automated/integration/api/test_review.py
@@ -3,9 +3,10 @@ import pytest
 from collector_db.constants import PLACEHOLDER_AGENCY_NAME
 from collector_db.models import URL, URLOptionalDataSourceMetadata, ConfirmedURLAgency, Agency
 from collector_manager.enums import URLStatus
-from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo, FinalReviewBaseInfo
+from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo, FinalReviewBaseInfo, RejectionReason, \
+    FinalReviewRejectionInfo
 from core.DTOs.GetNextURLForFinalReviewResponse import GetNextURLForFinalReviewOuterResponse
-from core.enums import RecordType
+from core.enums import RecordType, SuggestedStatus
 from tests.helpers.complex_test_data_functions import setup_for_get_next_url_for_final_review
 
 
@@ -46,7 +47,7 @@ async def test_review_next_source(api_test_helper):
     annotation_info = result.annotations
     relevant_info = annotation_info.relevant
     assert relevant_info.auto == True
-    assert relevant_info.user == False
+    assert relevant_info.user == SuggestedStatus.NOT_RELEVANT
 
     record_type_info = annotation_info.record_type
     assert record_type_info.auto == RecordType.ARREST_RECORDS
@@ -132,8 +133,12 @@ async def test_approve_and_get_next_source_for_review(api_test_helper):
         if agency.agency_id == additional_agency:
             assert agency.name == PLACEHOLDER_AGENCY_NAME
 
-@pytest.mark.asyncio
-async def test_reject_and_get_next_source_for_review(api_test_helper):
+
+async def test_rejection(
+    api_test_helper,
+    rejection_reason: RejectionReason,
+    url_status: URLStatus
+):
     ath = api_test_helper
     db_data_creator = ath.db_data_creator
 
@@ -145,8 +150,9 @@ async def test_reject_and_get_next_source_for_review(api_test_helper):
     url_mapping = setup_info.url_mapping
 
     result: GetNextURLForFinalReviewOuterResponse = await ath.request_validator.reject_and_get_next_source_for_review(
-        review_info=FinalReviewBaseInfo(
+        review_info=FinalReviewRejectionInfo(
             url_id=url_mapping.url_id,
+            rejection_reason=rejection_reason
         )
     )
 
@@ -154,8 +160,33 @@ async def test_reject_and_get_next_source_for_review(api_test_helper):
 
     adb_client = db_data_creator.adb_client
     # Confirm same agency id is listed as rejected
-    urls = await adb_client.get_all(URL)
+    urls: list[URL] = await adb_client.get_all(URL)
     assert len(urls) == 1
     url = urls[0]
     assert url.id == url_mapping.url_id
-    assert url.outcome == URLStatus.NOT_RELEVANT.value
+    assert url.outcome == url_status.value
+
+@pytest.mark.asyncio
+async def test_rejection_not_relevant(api_test_helper):
+    await test_rejection(
+        api_test_helper,
+        rejection_reason=RejectionReason.NOT_RELEVANT,
+        url_status=URLStatus.NOT_RELEVANT
+    )
+
+@pytest.mark.asyncio
+async def test_rejection_broken_page(api_test_helper):
+    await test_rejection(
+        api_test_helper,
+        rejection_reason=RejectionReason.BROKEN_PAGE_404,
+        url_status=URLStatus.NOT_FOUND
+    )
+
+@pytest.mark.asyncio
+async def test_rejection_individual_record(api_test_helper):
+    await test_rejection(
+        api_test_helper,
+        rejection_reason=RejectionReason.INDIVIDUAL_RECORD,
+        url_status=URLStatus.INDIVIDUAL_RECORD
+    )
+

--- a/tests/test_automated/integration/api/test_review.py
+++ b/tests/test_automated/integration/api/test_review.py
@@ -134,7 +134,7 @@ async def test_approve_and_get_next_source_for_review(api_test_helper):
             assert agency.name == PLACEHOLDER_AGENCY_NAME
 
 
-async def test_rejection(
+async def run_rejection_test(
     api_test_helper,
     rejection_reason: RejectionReason,
     url_status: URLStatus
@@ -168,7 +168,7 @@ async def test_rejection(
 
 @pytest.mark.asyncio
 async def test_rejection_not_relevant(api_test_helper):
-    await test_rejection(
+    await run_rejection_test(
         api_test_helper,
         rejection_reason=RejectionReason.NOT_RELEVANT,
         url_status=URLStatus.NOT_RELEVANT
@@ -176,7 +176,7 @@ async def test_rejection_not_relevant(api_test_helper):
 
 @pytest.mark.asyncio
 async def test_rejection_broken_page(api_test_helper):
-    await test_rejection(
+    await run_rejection_test(
         api_test_helper,
         rejection_reason=RejectionReason.BROKEN_PAGE_404,
         url_status=URLStatus.NOT_FOUND
@@ -184,7 +184,7 @@ async def test_rejection_broken_page(api_test_helper):
 
 @pytest.mark.asyncio
 async def test_rejection_individual_record(api_test_helper):
-    await test_rejection(
+    await run_rejection_test(
         api_test_helper,
         rejection_reason=RejectionReason.INDIVIDUAL_RECORD,
         url_status=URLStatus.INDIVIDUAL_RECORD

--- a/tests/test_automated/integration/api/test_review.py
+++ b/tests/test_automated/integration/api/test_review.py
@@ -158,4 +158,4 @@ async def test_reject_and_get_next_source_for_review(api_test_helper):
     assert len(urls) == 1
     url = urls[0]
     assert url.id == url_mapping.url_id
-    assert url.outcome == URLStatus.REJECTED.value
+    assert url.outcome == URLStatus.NOT_RELEVANT.value

--- a/tests/test_automated/integration/collector_db/test_db_client.py
+++ b/tests/test_automated/integration/collector_db/test_db_client.py
@@ -13,7 +13,7 @@ from collector_db.constants import PLACEHOLDER_AGENCY_NAME
 from collector_db.models import URL, ReviewingUserURL, URLOptionalDataSourceMetadata, ConfirmedURLAgency, Agency
 from collector_manager.enums import URLStatus
 from core.DTOs.FinalReviewApprovalInfo import FinalReviewApprovalInfo
-from core.enums import BatchStatus, RecordType, SuggestionType
+from core.enums import BatchStatus, RecordType, SuggestionType, SuggestedStatus
 from tests.helpers.complex_test_data_functions import setup_for_get_next_url_for_annotation, setup_for_annotate_agency
 from tests.helpers.DBDataCreator import DBDataCreator
 from tests.helpers.complex_test_data_functions import setup_for_get_next_url_for_final_review
@@ -186,7 +186,7 @@ async def test_get_next_url_for_final_review_basic(db_data_creator: DBDataCreato
     annotation_info = result.annotations
     relevant_info = annotation_info.relevant
     assert relevant_info.auto == True
-    assert relevant_info.user == False
+    assert relevant_info.user == SuggestedStatus.NOT_RELEVANT
 
     record_type_info = annotation_info.record_type
     assert record_type_info.auto == RecordType.ARREST_RECORDS
@@ -465,7 +465,7 @@ async def test_get_next_url_for_user_relevance_annotation_pending(
     await adb_client.add_user_relevant_suggestion(
         url_id=url_1.url_info.url_id,
         user_id=1,
-        relevant=True
+        suggested_status=SuggestedStatus.RELEVANT
     )
 
     url_3 = await adb_client.get_next_url_for_relevance_annotation(
@@ -617,12 +617,12 @@ async def test_annotate_url_marked_not_relevant(db_data_creator: DBDataCreator):
     await adb_client.add_user_relevant_suggestion(
         user_id=1,
         url_id=url_to_mark_not_relevant.url_id,
-        relevant=False
+        suggested_status=SuggestedStatus.NOT_RELEVANT
     )
     await adb_client.add_user_relevant_suggestion(
         user_id=1,
         url_id=url_to_mark_relevant.url_id,
-        relevant=True
+        suggested_status=SuggestedStatus.RELEVANT
     )
 
     # User should not receive the URL for record type annotation

--- a/tests/test_automated/unit/dto/test_all_annotation_post_info.py
+++ b/tests/test_automated/unit/dto/test_all_annotation_post_info.py
@@ -1,8 +1,7 @@
 import pytest
-from pydantic import ValidationError
 
 from core.DTOs.AllAnnotationPostInfo import AllAnnotationPostInfo
-from core.enums import RecordType
+from core.enums import RecordType, SuggestedStatus
 from core.exceptions import FailedValidationException
 
 # Mock values to pass
@@ -10,21 +9,21 @@ mock_record_type = RecordType.ARREST_RECORDS.value  # replace with valid RecordT
 mock_agency = {"is_new": False, "suggested_agency": 1}  # replace with a valid dict for the URLAgencyAnnotationPostInfo model
 
 @pytest.mark.parametrize(
-    "is_relevant, record_type, agency, should_raise",
+    "suggested_status, record_type, agency, should_raise",
     [
-        (True,  mock_record_type, mock_agency, False),  # valid
-        (True,  None,            mock_agency, True),   # missing record_type
-        (True,  mock_record_type, None,       True),   # missing agency
-        (True,  None,            None,        True),   # missing both
-        (False, None,            None,        False),  # valid
-        (False, mock_record_type, None,       True),   # record_type present
-        (False, None,            mock_agency, True),   # agency present
-        (False, mock_record_type, mock_agency, True),  # both present
+        (SuggestedStatus.RELEVANT,  mock_record_type, mock_agency, False),  # valid
+        (SuggestedStatus.RELEVANT,  None,            mock_agency, True),   # missing record_type
+        (SuggestedStatus.RELEVANT,  mock_record_type, None,       True),   # missing agency
+        (SuggestedStatus.RELEVANT,  None,            None,        True),   # missing both
+        (SuggestedStatus.NOT_RELEVANT, None,            None,        False),  # valid
+        (SuggestedStatus.NOT_RELEVANT, mock_record_type, None,       True),   # record_type present
+        (SuggestedStatus.NOT_RELEVANT, None,            mock_agency, True),   # agency present
+        (SuggestedStatus.NOT_RELEVANT, mock_record_type, mock_agency, True),  # both present
     ]
 )
-def test_all_annotation_post_info_validation(is_relevant, record_type, agency, should_raise):
+def test_all_annotation_post_info_validation(suggested_status, record_type, agency, should_raise):
     data = {
-        "is_relevant": is_relevant,
+        "suggested_status": suggested_status.value,
         "record_type": record_type,
         "agency": agency
     }
@@ -34,4 +33,4 @@ def test_all_annotation_post_info_validation(is_relevant, record_type, agency, s
             AllAnnotationPostInfo(**data)
     else:
         model = AllAnnotationPostInfo(**data)
-        assert model.is_relevant == is_relevant
+        assert model.suggested_status == suggested_status


### PR DESCRIPTION
https://github.com/Police-Data-Accessibility-Project/data-source-identification/issues/223

Overhaul rejection/relevancy annotation logic 

Update `/annotate/relevance/{url_id}` to accept `relevant`, `not relevant`, `broken page`, `single_record` entries
Update `/annotate/all/{url_id}` to do the same
Update `/review/reject-source` to allow specification of a `rejection_reason` including `not relevant`, `broken page`, and `single record`
Update database such that URL have status `rejected` replaced with `not relevant` and add additional status `individual record`