### PR TITLE
Remove ReviewDog and add lint directives to CLAUDE.md

### DIFF
--- a/.github/workflows/python_checks.yml
+++ b/.github/workflows/python_checks.yml
@@ -14,9 +14,5 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install flake8 flake8-docstrings flake8-simplify flake8-unused-arguments flake8-annotations
-      - name: flake8 Lint with Reviewdog
-        uses: reviewdog/action-flake8@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          flake8_args: --ignore E501,W291,W293,D401,D400,E402,E302,D200,D202,D205,W503,E203,D204,D403
-          level: warning
+      - name: Run flake8
+        run: flake8 . --ignore E501,W291,W293,D401,D400,E402,E302,D200,D202,D205,W503,E203,D204,D403

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,10 @@ See `ENV.md` for the full reference. Key categories:
 
 ## Important Notes
 
+- Follow the repository's linting style guide when writing or editing Python:
+  - Run `flake8` with this exact ignore set in mind: `E501,W291,W293,D401,D400,E402,E302,D200,D202,D205,W503,E203,D204,D403`
+  - Keep import ordering and blank-line usage compliant with `flake8` defaults aside from the ignore list above
+  - Prefer concise docstrings where present and avoid introducing new docstring violations outside ignored codes
 - The app exposes its API docs at `/api` (not the default `/docs` — `/docs` redirects to `/api`).
 - CORS is configured for `localhost:8888`, `pdap.io`, and `pdap.dev`.
 - Two permission levels: `access_source_collector` (general) and `source_collector_final_review` (final review).


### PR DESCRIPTION
## Summary
- remove the ReviewDog flake8 GitHub Action usage
- run flake8 directly in CI with the existing ignore list
- add explicit lint/style directives to CLAUDE.md

Closes #592