### PR TITLE
Add auth guards to sensitive mutating endpoints

### DIFF
--- a/src/api/endpoints/proposals/routes.py
+++ b/src/api/endpoints/proposals/routes.py
@@ -74,7 +74,10 @@ async def get_agency_locations(
         GetProposalAgencyLocationsQueryBuilder(agency_id=proposed_agency_id)
     )
 
-@proposal_router.post("/agencies/{proposed_agency_id}/locations/{location_id}")
+@proposal_router.post(
+    "/agencies/{proposed_agency_id}/locations/{location_id}",
+    dependencies=[Depends(get_admin_access_info)],
+)
 async def add_location_to_agency(
     proposed_agency_id: int = Path(
         description="Agency ID to add location to"
@@ -89,7 +92,10 @@ async def add_location_to_agency(
     )
     return MessageResponse(message="Location added to agency.")
 
-@proposal_router.delete("/agencies/{proposed_agency_id}/locations/{location_id}")
+@proposal_router.delete(
+    "/agencies/{proposed_agency_id}/locations/{location_id}",
+    dependencies=[Depends(get_admin_access_info)],
+)
 async def remove_location_from_agency(
     proposed_agency_id: int = Path(
         description="Agency ID to remove location from"
@@ -104,7 +110,10 @@ async def remove_location_from_agency(
     )
     return MessageResponse(message="Location removed from agency.")
 
-@proposal_router.put("/agencies/{proposed_agency_id}")
+@proposal_router.put(
+    "/agencies/{proposed_agency_id}",
+    dependencies=[Depends(get_admin_access_info)],
+)
 async def update_agency(
     request: ProposalAgencyPutRequest,
     proposed_agency_id: int = Path(

--- a/src/api/endpoints/submit/routes.py
+++ b/src/api/endpoints/submit/routes.py
@@ -40,7 +40,8 @@ async def submit_url(
         409: {
             "model": SubmitDataSourceURLDuplicateSubmissionResponse
         }
-    }
+    },
+    dependencies=[Depends(get_standard_user_access_info)]
 )
 async def submit_data_source(
     request: DataSourceSubmissionRequest,

--- a/tests/automated/integration/api/test_sensitive_endpoint_auth_config.py
+++ b/tests/automated/integration/api/test_sensitive_endpoint_auth_config.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_proposal_mutation_routes_require_admin_auth():
+    proposals_routes = (
+        ROOT / "src" / "api" / "endpoints" / "proposals" / "routes.py"
+    ).read_text()
+
+    assert '"/agencies/{proposed_agency_id}/locations/{location_id}",\n    dependencies=[Depends(get_admin_access_info)],' in proposals_routes
+    assert '"/agencies/{proposed_agency_id}",\n    dependencies=[Depends(get_admin_access_info)],' in proposals_routes
+
+
+def test_submit_data_source_requires_authenticated_user():
+    submit_routes = (
+        ROOT / "src" / "api" / "endpoints" / "submit" / "routes.py"
+    ).read_text()
+
+    assert (
+        '"/data-source",\n'
+        "    response_model=SubmitDataSourceURLProposalResponse,\n"
+        "    responses={\n"
+        "        409: {\n"
+        '            "model": SubmitDataSourceURLDuplicateSubmissionResponse\n'
+        "        }\n"
+        "    },\n"
+        "    dependencies=[Depends(get_standard_user_access_info)]"
+    ) in submit_routes


### PR DESCRIPTION
## Summary
- require admin auth for proposal mutation endpoints that were missing protection
- require authenticated user auth for 
- add regression test coverage to prevent future auth drift on these routes

## Testing
- uv run pytest -q tests/automated/integration/api/test_sensitive_endpoint_auth_config.py

Closes #574