### PR TITLE
Add Alembic merge migration to resolve multiple heads

### DIFF
--- a/alembic/versions/2026_04_05_0632-924efb71ef2d_merge_multiple_alembic_heads.py
+++ b/alembic/versions/2026_04_05_0632-924efb71ef2d_merge_multiple_alembic_heads.py
@@ -1,0 +1,23 @@
+"""Merge multiple Alembic heads
+
+Revision ID: 924efb71ef2d
+Revises: c4f9bbf8a201, a1b2c3d4e5f6
+Create Date: 2026-04-05 06:32:10.302444
+
+"""
+from typing import Optional, Sequence, Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = '924efb71ef2d'
+down_revision: Optional[str] = ('c4f9bbf8a201', 'a1b2c3d4e5f6')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Merge heads."""
+
+
+def downgrade() -> None:
+    """Merge heads."""


### PR DESCRIPTION
## Summary
- Adds a merge migration to unify the two divergent Alembic heads (`c4f9bbf8a201` and `a1b2c3d4e5f6`) on `dev`
- This resolves the `Multiple head revisions are present` error that is causing all CI tests to fail on PR #603

## Test plan
- [ ] CI passes — `alembic upgrade head` should no longer error with multiple heads
- [ ] `alembic heads` shows a single head

🤖 Generated with [Claude Code](https://claude.com/claude-code)